### PR TITLE
Enhance repository bumping workflow and script

### DIFF
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: 5.0.0
+        default: main
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: 5.0.0
+        default: main
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -5,23 +5,28 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Target version (e.g. 5.0.0)'
-        default: ''
+        description: "Target version (e.g. 5.0.0)"
+        default: ""
         required: false
         type: string
       stage:
-        description: 'Version stage (e.g. alpha0)'
-        default: ''
+        description: "Version stage (e.g. alpha0)"
+        default: ""
         required: false
         type: string
       issue-link:
-        description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
+        description: "Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>"
         required: true
         type: string
       id:
-        description: 'Optional identifier for the run'
+        description: "Optional identifier for the run"
         required: false
         type: string
+      set_as_main:
+        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   bump:
@@ -67,6 +72,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # Using workflow-specific GITHUB_TOKEN because currently CI_WAZUHCI_BUMPER_TOKEN
+          # doesn't have all the necessary permissions
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine branch name
@@ -74,6 +81,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          set_as_main: ${{ inputs.set_as_main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
@@ -84,6 +92,10 @@ jobs:
             script_params="--version ${version} --stage ${stage}"
           elif [[ -z "$version" && -n "$stage" ]]; then
             script_params="--stage ${stage}"
+          fi
+
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params="${script_params} --set_as_main"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
@@ -100,7 +112,17 @@ jobs:
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
+      - name: Detect if bump produced changes
+        id: bump_changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Commit and push changes
+        if: steps.bump_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
@@ -108,6 +130,7 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.bump_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -120,13 +143,19 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.bump_changes.outputs.has_changes == 'true'
         run: |
+          # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge
 
       - name: Show logs
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: https://github.com/${{ github.repository }}/pull/${{ steps.create_pr.outputs.pull_request_number }}"
+          if [[ "${{ steps.bump_changes.outputs.has_changes }}" == "true" ]]; then
+            echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+            echo "No file changes from bumper (no PR created)."
+          fi
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -14,6 +14,8 @@ VERSION=""
 REVISION="00"
 TAG=false
 CURRENT_VERSION=""
+# When --set_as_main: skip replacing branch refs (e.g. main) in workflows; set in parse_arguments()
+skip_urls="no"
 
 # Function to log messages
 log() {
@@ -32,6 +34,8 @@ usage() {
   echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
   echo "                      Required if --tag is not used"
   echo "  --tag               Generate a tag"
+  echo "  --set_as_main       Bump version values only; keep branch defaults (e.g. main) unchanged"
+  echo "                      (alias: --set-as-main)"
   echo "  --help              Display this help message"
   echo ""
   echo "Example:"
@@ -205,6 +209,10 @@ parse_arguments() {
       TAG=true
       shift
       ;;
+    --set_as_main|--set-as-main)
+      set_as_main="yes"
+      shift 1
+      ;;
     --help)
       usage
       exit 0
@@ -216,6 +224,12 @@ parse_arguments() {
       ;;
     esac
   done
+
+  if [[ -n "$set_as_main" ]]; then
+    skip_urls="yes"
+  else
+    skip_urls="no"
+  fi
 }
 
 # Function to validate input parameters
@@ -444,6 +458,29 @@ update_manual_build_workflow() {
   log "Updating $WAZUH_DASHBOARD_ALERTING_WORKFLOW_FILE workflow..."
 }
 
+# Replace "main" in default: reference inputs (5_* workflows only) when not in --set_as_main mode.
+update_branch_reference_defaults() {
+  if [[ "$skip_urls" == "yes" ]]; then
+    log "skip_urls is yes (--set_as_main): leaving workflow branch defaults unchanged"
+    return 0
+  fi
+
+  local bump_string="$VERSION"
+  local files=(
+    "${REPO_PATH}/.github/workflows/5_builderpackage_alerting_plugin.yml"
+    "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
+  )
+  local f
+  for f in "${files[@]}"; do
+    if [ ! -f "$f" ]; then
+      log "WARNING: $f not found. Skipping main→${bump_string} default update."
+      continue
+    fi
+    log "Replacing default: main with default: ${bump_string} in $f (where applicable)"
+    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
+  done
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -478,6 +515,7 @@ main() {
   update_root_version_json
   update_package_json
   update_changelog
+  update_branch_reference_defaults
   update_manual_build_workflow
 
   log "File modifications completed."


### PR DESCRIPTION
### Description

This PR adds support for the `--set_as_main` / `--set-as-main` CLI flags in the repository bumper (and the `set_as_main` workflow input), aligned with the two-step version bump flow from `main` ([wazuh-qa-automation#6246](https://github.com/wazuh/wazuh-qa-automation/issues/6246)).

**Changes**

- `tools/repository_bumper.sh`: parses `--set_as_main` or `--set-as-main` and sets `skip_urls`. When **not** in that mode, rewrites `default: main` to `default: <version>` in:
  - `.github/workflows/5_builderpackage_alerting_plugin.yml`
  - `.github/workflows/5_builderprecompiled_base-dev-environment.yml`  
  When `skip_urls` is set (set-as-main mode), those `main` → version replacements are skipped; `VERSION.json`, `package.json`, and `CHANGELOG.md` are still updated. The manual build workflow file may still have its `default` updated from the previous version number to the new one via the existing `update_manual_build_workflow` step where applicable.
- `.github/workflows/5_bumper_repository.yml`: adds `set_as_main` input, appends `--set_as_main` to the script when enabled, and skips commit/PR/merge when the bumper produces no changes.

### Issues resolved

Closes [#11](https://github.com/wazuh/wazuh-dashboard-alerting/issues/11)

### How to test

From the repository root (adjust version/stage if your current `VERSION.json` does not allow the example bump; example uses **5.0.0 → 5.0.1**).

**A — `set_as_main` (workflow equivalent: `set_as_main=true`)**

```bash
bash tools/repository_bumper.sh --version 5.0.1 --stage alpha0 --set_as_main
git diff --stat
grep "default:" .github/workflows/5_builderpackage_alerting_plugin.yml | head -4
grep -n "default: main" .github/workflows/5_builderprecompiled_base-dev-environment.yml || true
```

**Expected:** `VERSION.json`, `package.json`, and `CHANGELOG.md` change; **`default: main`** remains on the `reference` input in `5_builderprecompiled_base-dev-environment.yml` (line with `default: main`).

<details>
<summary>Real output — scenario A (<code>bash tools/repository_bumper.sh --version 5.0.1 --stage alpha0 --set_as_main</code>)</summary>

```
[2026-03-30 11:05:55] Starting repository bump process
[2026-03-30 11:05:55] Repository path: /home/asus/wazuh/wazuh-dashboard-alerting
[2026-03-30 11:05:55] Version: 5.0.1
[2026-03-30 11:05:55] Stage: alpha0
[2026-03-30 11:05:55] Attempting to extract current version from /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-03-30 11:05:55] Successfully extracted version using sed: 5.0.0
[2026-03-30 11:05:55] Current version detected in VERSION.json: 5.0.0
[2026-03-30 11:05:55] Attempting to extract current stage from /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-03-30 11:05:55] Successfully extracted stage using sed: alpha0
[2026-03-30 11:05:55] Current stage detected in VERSION.json: alpha0
[2026-03-30 11:05:55] Attempting to extract current revision from /home/asus/wazuh/wazuh-dashboard-alerting/package.json using sed...
[2026-03-30 11:05:55] Successfully extracted revision using sed: 00
[2026-03-30 11:05:55] Current revision detected in package.json: 00
[2026-03-30 11:05:55] Default revision set to: 00
[2026-03-30 11:05:55] Comparing new version (5.0.1) with current version (5.0.0)...
[2026-03-30 11:05:55] Version check passed: New version (5.0.1) is greater than current version (5.0.0) (Patch increased).
[2026-03-30 11:05:55] Final revision determined: 00
[2026-03-30 11:05:55] Starting file modifications...
[2026-03-30 11:05:55] Processing /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json
[2026-03-30 11:05:55] Successfully updated /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json with new version: 5.0.1 and stage: alpha0
[2026-03-30 11:05:55] Processing /home/asus/wazuh/wazuh-dashboard-alerting/package.json
[2026-03-30 11:05:55] Attempting to update version to 5.0.1 within 'wazuh' object in /home/asus/wazuh/wazuh-dashboard-alerting/package.json
[2026-03-30 11:05:55] Successfully updated /home/asus/wazuh/wazuh-dashboard-alerting/package.json with new version: 5.0.1 and revision: 00
[2026-03-30 11:05:55] Updating CHANGELOG.md...
[2026-03-30 11:05:55] Attempting to extract .version from /home/asus/wazuh/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-03-30 11:05:55] Detected OpenSearch Dashboards version for changelog: 3.5.0
[2026-03-30 11:05:55] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-03-30 11:05:55] CHANGELOG.md updated successfully.
[2026-03-30 11:05:55] skip_urls is yes (--set_as_main): leaving workflow branch defaults unchanged
[2026-03-30 11:05:55] Processing /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml
[2026-03-30 11:05:55] Attempting to update default reference to 5.0.1 in /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml
[2026-03-30 11:05:55] Successfully updated /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml with new default reference: 5.0.1
[2026-03-30 11:05:55] Updating /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml workflow...
[2026-03-30 11:05:55] File modifications completed.
[2026-03-30 11:05:55] Repository bump completed successfully. Log file: /home/asus/wazuh/wazuh-dashboard-alerting/tools/repository_bumper_2026-03-30_11-05-55-152.log
```

```
$ grep -n "default: main" .github/workflows/5_builderprecompiled_base-dev-environment.yml
9:        default: main

$ git diff --stat VERSION.json package.json CHANGELOG.md .github/workflows/5_builderpackage_alerting_plugin.yml .github/workflows/5_builderprecompiled_base-dev-environment.yml
 .github/workflows/5_builderpackage_alerting_plugin.yml | 4 ++--
 CHANGELOG.md                                           | 6 ++++++
 VERSION.json                                           | 2 +-
 package.json                                           | 2 +-
 4 files changed, 10 insertions(+), 4 deletions(-)
```

(`5_builderprecompiled_base-dev-environment.yml` has no diff: `default: main` is preserved.)

</details>

**B — normal bump (`set_as_main` not set)**

```bash
git checkout -- VERSION.json package.json CHANGELOG.md \
  .github/workflows/5_builderpackage_alerting_plugin.yml \
  .github/workflows/5_builderprecompiled_base-dev-environment.yml
bash tools/repository_bumper.sh --version 5.0.1 --stage alpha0
grep "default:" .github/workflows/5_builderprecompiled_base-dev-environment.yml | head -4
grep "default:" .github/workflows/5_builderpackage_alerting_plugin.yml | head -4
```

**Expected:** `default: main` becomes `default: 5.0.1` in both `5_*` workflows where the script applies the replacement.

<details>
<summary>Real output — scenario B (<code>bash tools/repository_bumper.sh --version 5.0.1 --stage alpha0</code>, no <code>--set_as_main</code>)</summary>

```
[2026-03-30 11:05:28] Starting repository bump process
[2026-03-30 11:05:28] Repository path: /home/asus/wazuh/wazuh-dashboard-alerting
[2026-03-30 11:05:28] Version: 5.0.1
[2026-03-30 11:05:28] Stage: alpha0
[2026-03-30 11:05:28] Attempting to extract current version from /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-03-30 11:05:28] Successfully extracted version using sed: 5.0.0
[2026-03-30 11:05:28] Current version detected in VERSION.json: 5.0.0
[2026-03-30 11:05:28] Attempting to extract current stage from /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-03-30 11:05:28] Successfully extracted stage using sed: alpha0
[2026-03-30 11:05:28] Current stage detected in VERSION.json: alpha0
[2026-03-30 11:05:28] Attempting to extract current revision from /home/asus/wazuh/wazuh-dashboard-alerting/package.json using sed...
[2026-03-30 11:05:28] Successfully extracted revision using sed: 00
[2026-03-30 11:05:28] Current revision detected in package.json: 00
[2026-03-30 11:05:28] Default revision set to: 00
[2026-03-30 11:05:28] Comparing new version (5.0.1) with current version (5.0.0)...
[2026-03-30 11:05:28] Version check passed: New version (5.0.1) is greater than current version (5.0.0) (Patch increased).
[2026-03-30 11:05:28] Final revision determined: 00
[2026-03-30 11:05:28] Starting file modifications...
[2026-03-30 11:05:28] Processing /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json
[2026-03-30 11:05:28] Successfully updated /home/asus/wazuh/wazuh-dashboard-alerting/VERSION.json with new version: 5.0.1 and stage: alpha0
[2026-03-30 11:05:28] Processing /home/asus/wazuh/wazuh-dashboard-alerting/package.json
[2026-03-30 11:05:28] Attempting to update version to 5.0.1 within 'wazuh' object in /home/asus/wazuh/wazuh-dashboard-alerting/package.json
[2026-03-30 11:05:28] Successfully updated /home/asus/wazuh/wazuh-dashboard-alerting/package.json with new version: 5.0.1 and revision: 00
[2026-03-30 11:05:28] Updating CHANGELOG.md...
[2026-03-30 11:05:28] Attempting to extract .version from /home/asus/wazuh/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-03-30 11:05:28] Detected OpenSearch Dashboards version for changelog: 3.5.0
[2026-03-30 11:05:28] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-03-30 11:05:28] CHANGELOG.md updated successfully.
[2026-03-30 11:05:29] Replacing default: main with default: 5.0.1 in /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml (where applicable)
[2026-03-30 11:05:29] Replacing default: main with default: 5.0.1 in /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-03-30 11:05:29] Processing /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml
[2026-03-30 11:05:29] Attempting to update default reference to 5.0.1 in /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml
[2026-03-30 11:05:29] Successfully updated /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml with new default reference: 5.0.1
[2026-03-30 11:05:29] Updating /home/asus/wazuh/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml workflow...
[2026-03-30 11:05:29] File modifications completed.
[2026-03-30 11:05:29] Repository bump completed successfully. Log file: /home/asus/wazuh/wazuh-dashboard-alerting/tools/repository_bumper_2026-03-30_11-05-28-871.log
```

```
$ sed -n '6,12p' .github/workflows/5_builderprecompiled_base-dev-environment.yml
      reference:
        required: true
        type: string
        default: 5.0.1
        description: Git reference (branch, tag, or commit SHA) to build from.
      command:
        required: true

$ grep "default:" .github/workflows/5_builderpackage_alerting_plugin.yml | head -4
        default: 5.0.1
        default: 5.0.1

$ git diff --stat VERSION.json package.json CHANGELOG.md .github/workflows/5_builderpackage_alerting_plugin.yml .github/workflows/5_builderprecompiled_base-dev-environment.yml
 .github/workflows/5_builderpackage_alerting_plugin.yml          | 4 ++--
 .github/workflows/5_builderprecompiled_base-dev-environment.yml | 2 +-
 CHANGELOG.md                                                    | 6 ++++++
 VERSION.json                                                    | 2 +-
 package.json                                                    | 2 +-
 5 files changed, 11 insertions(+), 5 deletions(-)
```

</details>

**Restore after local testing**

```bash
git checkout -- VERSION.json package.json CHANGELOG.md \
  .github/workflows/5_builderpackage_alerting_plugin.yml \
  .github/workflows/5_builderprecompiled_base-dev-environment.yml
```

### Evidence (for reviewers)

- Paste or attach `git diff --stat` output for scenarios **A** and **B**.
- Optional: link or screenshot of a successful **Repository bumper** workflow run with `set_as_main` true/false.

### Checklist

- [ ] Commits are signed per the DCO using `--signoff`
