### PR TITLE
Extraction query editor is not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 ### Changed
 
 - Changed category in the side menu to `Explore` [#4](https://github.com/wazuh/wazuh-dashboard-alerting/pull/4)
+
+### Fixed
+
+- Fixed request execution in Extraction Query Editor [#24](https://github.com/wazuh/wazuh-dashboard-alerting/pull/24)

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
@@ -78,25 +78,22 @@ const MonitorDefinitionCard = ({ values, plugins }) => {
             }}
           />
         </EuiFlexItem>
-        {/* Wazuh: hide the extraction query editor option for doc level monitor */}
-        {values.monitor_type !== MONITOR_TYPE.DOC_LEVEL && (
-          <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>
-            <FormikCheckableCard
-              name="searchTypeQuery"
-              formRow
-              inputProps={{
-                id: 'extractionQueryEditorRadioCard',
-                label: 'Extraction query editor',
-                checked: values.searchType === SEARCH_TYPE.QUERY,
-                value: SEARCH_TYPE.QUERY,
-                onChange: (e, field, form) => {
-                  onChangeDefinition(e, form, values);
-                },
-                'data-test-subj': 'extractionQueryEditorRadioCard',
-              }}
-            />
-          </EuiFlexItem>
-        )}
+        <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>
+          <FormikCheckableCard
+            name="searchTypeQuery"
+            formRow
+            inputProps={{
+              id: 'extractionQueryEditorRadioCard',
+              label: 'Extraction query editor',
+              checked: values.searchType === SEARCH_TYPE.QUERY,
+              value: SEARCH_TYPE.QUERY,
+              onChange: (e, field, form) => {
+                onChangeDefinition(e, form, values);
+              },
+              'data-test-subj': 'extractionQueryEditorRadioCard',
+            }}
+          />
+        </EuiFlexItem>
         {/*// Only show the anomaly detector option when anomaly detection plugin is present, and for supporting monitors.*/}
         {hasADPlugin && supportsADOption && (
           <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -82,7 +82,7 @@ export const FORMIK_INITIAL_VALUES = {
 };
 
 if (dataSourceEnabled()) {
-  FORMIK_INITIAL_VALUES["dataSourceId"] = "random-dataSourceId";
+  FORMIK_INITIAL_VALUES['dataSourceId'] = 'random-dataSourceId';
 }
 
 export const FORMIK_INITIAL_AGG_VALUES = {
@@ -106,7 +106,7 @@ export const DEFAULT_DOCUMENT_LEVEL_QUERY = JSON.stringify(
     queries: [
       {
         name: 'QUERY_NAME',
-        query: { match_all: {} },
+        query: '*',
         tags: ['TAG_TEXT'],
       },
     ],

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -82,7 +82,7 @@ export const FORMIK_INITIAL_VALUES = {
 };
 
 if (dataSourceEnabled()) {
-  FORMIK_INITIAL_VALUES['dataSourceId'] = 'random-dataSourceId';
+  FORMIK_INITIAL_VALUES["dataSourceId"] = "random-dataSourceId";
 }
 
 export const FORMIK_INITIAL_AGG_VALUES = {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -106,7 +106,7 @@ export const DEFAULT_DOCUMENT_LEVEL_QUERY = JSON.stringify(
     queries: [
       {
         name: 'QUERY_NAME',
-        query: '*',
+        query: '*', // Wazuh: use DQL instead
         tags: ['TAG_TEXT'],
       },
     ],

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -349,9 +349,12 @@ class DefineMonitor extends Component {
     // Cancel execution criteria
     switch (monitor_type) {
       case MONITOR_TYPE.DOC_LEVEL:
-        const { queries } = values;
-        const canExecute = searchType === SEARCH_TYPE.GRAPH && validDocLevelGraphQueries(queries);
-        if (!canExecute) return;
+        // Wazuh: fix conditional to only run validation for doc level graph queries
+        if (searchType === SEARCH_TYPE.GRAPH) {
+          const { queries } = values;
+          if (!validDocLevelGraphQueries(queries)) return;
+        }
+        break;
     }
     this.setState({ loadingResponse: true });
 

--- a/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
+++ b/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
@@ -53,10 +53,7 @@ const MonitorDetails = ({
 }) => {
   const anomalyDetectorContent =
     isAd && renderAnomalyDetector({ httpClient, values, detectorId, flyoutMode });
-  // Wazuh: hide monitor defining method options for doc level monitor
-  const displayMonitorDefinitionCards =
-    values.monitor_type !== MONITOR_TYPE.CLUSTER_METRICS &&
-    values.monitor_type !== MONITOR_TYPE.DOC_LEVEL;
+  const displayMonitorDefinitionCards = values.monitor_type !== MONITOR_TYPE.CLUSTER_METRICS;
   const Container = useMemo(
     () => (flyoutMode ? ({ children }) => <>{children}</> : ContentPanel),
     [flyoutMode]


### PR DESCRIPTION
### Description
Fixes conditional that was causing non graph search types (SEARCH_TYPE.QUERY in this case) requests to not execute.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-alerting/issues/21

### Evidence

https://github.com/user-attachments/assets/ae1ae7f5-55e3-4c0d-8e27-3266a84de440

### Test

- Go to `Alerting` > `Monitors` > `Create monitor`, select a `Per document monitor` type, select an index, and verify 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
