### PR TITLE
Hide the extraction query editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 - Changed category in the side menu to `Explore` [#4](https://github.com/wazuh/wazuh-dashboard-alerting/pull/4)
 - Support `date` and `ip` type fields in document level queries [#22](https://github.com/wazuh/wazuh-dashboard-alerting/pull/22)
 - Hide "Add active response" button for all monitor types except "Per document monitor" / Do not auto-load notification form when adding a trigger. [#18](https://github.com/wazuh/wazuh-dashboard-alerting/pull/18)
+- Hide `Extraction query editor` for per document monitors in `Create/edit monitor` form [#26](https://github.com/wazuh/wazuh-dashboard-alerting/pull/26)

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
@@ -78,22 +78,24 @@ const MonitorDefinitionCard = ({ values, plugins }) => {
             }}
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>
-          <FormikCheckableCard
-            name="searchTypeQuery"
-            formRow
-            inputProps={{
-              id: 'extractionQueryEditorRadioCard',
-              label: 'Extraction query editor',
-              checked: values.searchType === SEARCH_TYPE.QUERY,
-              value: SEARCH_TYPE.QUERY,
-              onChange: (e, field, form) => {
-                onChangeDefinition(e, form, values);
-              },
-              'data-test-subj': 'extractionQueryEditorRadioCard',
-            }}
-          />
-        </EuiFlexItem>
+        {values.monitor_type !== MONITOR_TYPE.DOC_LEVEL && (
+          <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>
+            <FormikCheckableCard
+              name="searchTypeQuery"
+              formRow
+              inputProps={{
+                id: 'extractionQueryEditorRadioCard',
+                label: 'Extraction query editor',
+                checked: values.searchType === SEARCH_TYPE.QUERY,
+                value: SEARCH_TYPE.QUERY,
+                onChange: (e, field, form) => {
+                  onChangeDefinition(e, form, values);
+                },
+                'data-test-subj': 'extractionQueryEditorRadioCard',
+              }}
+            />
+          </EuiFlexItem>
+        )}
         {/*// Only show the anomaly detector option when anomaly detection plugin is present, and for supporting monitors.*/}
         {hasADPlugin && supportsADOption && (
           <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
@@ -78,7 +78,7 @@ const MonitorDefinitionCard = ({ values, plugins }) => {
             }}
           />
         </EuiFlexItem>
-        {/* // Wazuh: hide the extraction query editor option for doc level monitor */}
+        {/* Wazuh: hide the extraction query editor option for doc level monitor */}
         {values.monitor_type !== MONITOR_TYPE.DOC_LEVEL && (
           <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>
             <FormikCheckableCard

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
@@ -78,6 +78,7 @@ const MonitorDefinitionCard = ({ values, plugins }) => {
             }}
           />
         </EuiFlexItem>
+        {/* // Wazuh: hide the extraction query editor option for doc level monitor */}
         {values.monitor_type !== MONITOR_TYPE.DOC_LEVEL && (
           <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>
             <FormikCheckableCard

--- a/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
+++ b/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
@@ -53,7 +53,10 @@ const MonitorDetails = ({
 }) => {
   const anomalyDetectorContent =
     isAd && renderAnomalyDetector({ httpClient, values, detectorId, flyoutMode });
-  const displayMonitorDefinitionCards = values.monitor_type !== MONITOR_TYPE.CLUSTER_METRICS;
+  // Wazuh: hide monitor defining method options for doc level monitor
+  const displayMonitorDefinitionCards =
+    values.monitor_type !== MONITOR_TYPE.CLUSTER_METRICS &&
+    values.monitor_type !== MONITOR_TYPE.DOC_LEVEL;
   const Container = useMemo(
     () => (flyoutMode ? ({ children }) => <>{children}</> : ContentPanel),
     [flyoutMode]


### PR DESCRIPTION
### Description
- Hide Monitor Defning Methods cards options in `Per Document` monitor, since the only option is Visual Editor.
- Hide Extraction Query Editor in Per Document monitor 
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-alerting/issues/25

### Evidence
<img width="2936" height="1496" alt="image" src="https://github.com/user-attachments/assets/296be7a4-5f39-43af-98b2-d80b159d3ce7" />
<img width="2904" height="1508" alt="image" src="https://github.com/user-attachments/assets/bfe1e3eb-d1cf-453f-b240-ae1a195eee9e" />

### Test
- Go to `Explore > Alerting > Create monitor`, select a `Per document level` type, and verify there is no way to select the extraction query editor.

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
