### PR TITLE
Add "Active Response" Monitor Type with Restricted Trigger Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 
 - Support for Wazuh 5.0.0
 - Added debounce to Document Level Query text inputs
+- Add "Active Response" monitor type [#33](https://github.com/wazuh/wazuh-dashboard-alerting/pull/33)
 
 ### Changed
 

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -300,6 +300,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
       case MONITOR_TYPE.BUCKET_LEVEL:
         return TRIGGER_TYPE.BUCKET_LEVEL;
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: allow AR monitor type
         return TRIGGER_TYPE.DOC_LEVEL;
       case MONITOR_TYPE.COMPOSITE_LEVEL:
         return TRIGGER_TYPE.COMPOSITE_LEVEL;
@@ -336,6 +337,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
         case MONITOR_TYPE.QUERY_LEVEL:
         case MONITOR_TYPE.CLUSTER_METRICS:
         case MONITOR_TYPE.DOC_LEVEL:
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         case MONITOR_TYPE.COMPOSITE_LEVEL:
           return `${item.id}-${item.version}`;
         case MONITOR_TYPE.BUCKET_LEVEL:
@@ -354,6 +356,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
           columns.push(CLUSTER_METRICS_CROSS_CLUSTER_ALERT_TABLE_COLUMN);
           break;
         case MONITOR_TYPE.DOC_LEVEL:
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
           columns = _.cloneDeep(queryColumns);
           columns.splice(
             0,
@@ -560,6 +563,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     switch (monitorType) {
       case MONITOR_TYPE.BUCKET_LEVEL:
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         displayMultipleConditions = true;
         break;
       default:
@@ -585,6 +589,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     let displayTableTabs;
     switch (monitorType) {
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         displayTableTabs = true;
         break;
       default:

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -152,7 +152,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
 
     const { monitorType, commentsEnabled, tabId } = this.state;
     if (
-      ([MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(monitorType) &&
+      ([MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL, MONITOR_TYPE.ACTIVE_RESPONSE].includes(monitorType) &&
         !_.isEqual(prevState.selectedItems, this.state.selectedItems)) ||
       (tabId === TABLE_TAB_IDS.ALERTS.id && commentsEnabled !== prevState.commentsEnabled)
     )
@@ -663,7 +663,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
               </p>
             </EuiText>
           </EuiFlexItem>
-          {![MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(monitorType) && (
+          {![MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL, MONITOR_TYPE.ACTIVE_RESPONSE].includes(monitorType) && (
             <EuiFlexItem>
               <EuiText size="s" data-test-subj={`alertsDashboardFlyout_timeRange_${trigger_name}`}>
                 <strong>Time range for the last</strong>
@@ -672,7 +672,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
             </EuiFlexItem>
           )}
         </EuiFlexGroup>
-        {![MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(monitorType) && (
+        {![MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL, MONITOR_TYPE.ACTIVE_RESPONSE].includes(monitorType) && (
           <div>
             <EuiSpacer size={'xxl'} />
             <EuiFlexGroup>

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -555,7 +555,9 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     const groupBy = _.get(monitor, MONITOR_GROUP_BY);
     const condition =
       searchType === SEARCH_TYPE.GRAPH &&
-      (monitorType === MONITOR_TYPE.BUCKET_LEVEL || monitorType === MONITOR_TYPE.DOC_LEVEL)
+      (monitorType === MONITOR_TYPE.BUCKET_LEVEL ||
+        monitorType === MONITOR_TYPE.DOC_LEVEL ||
+        monitorType === MONITOR_TYPE.ACTIVE_RESPONSE) // Wazuh: Handle Active Response monitor type
         ? this.getMultipleGraphConditions(trigger)
         : _.get(trigger, 'condition.script.source', DEFAULT_EMPTY_DATA);
 

--- a/public/pages/CreateMonitor/components/CrossClusterConfigurations/utils/helpers.js
+++ b/public/pages/CreateMonitor/components/CrossClusterConfigurations/utils/helpers.js
@@ -39,6 +39,7 @@ export const getDataSources = (monitor, localClusterName) => {
       if (_.isEmpty(dataSources)) dataSources = [localClusterName || DEFAULT_EMPTY_DATA];
       break;
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       dataSources = _.get(monitor, 'inputs.0.doc_level_input.indices', [DEFAULT_EMPTY_DATA]);
       break;
     default:

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
@@ -30,6 +30,7 @@ const onChangeDefinition = (e, form) => {
     case MONITOR_TYPE.CLUSTER_METRICS:
       form.setFieldValue('searchType', SEARCH_TYPE.CLUSTER_METRICS);
       break;
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
     case MONITOR_TYPE.DOC_LEVEL:
       form.setFieldValue('query', DEFAULT_DOCUMENT_LEVEL_QUERY);
       break;
@@ -85,6 +86,14 @@ const pplDescription = (
   <EuiText color={'subdued'} size={'xs'} style={{ paddingBottom: '10px', paddingTop: '0px' }}>
     PPL monitors use Piped Processing Language queries to monitor data and generate alerts based on
     query results.
+  </EuiText>
+);
+
+// Wazuh: Add description for Active Response monitor type
+const activeResponseDescription = (
+  <EuiText color={'subdued'} size={'xs'} style={{ paddingBottom: '10px', paddingTop: '0px' }}>
+    Active Response monitors trigger active responses when documents match the trigger
+    conditions.
   </EuiText>
 );
 
@@ -179,6 +188,21 @@ const MonitorType = ({ values }) => (
           />
         </EuiFlexItem>
       )}
+      {/* Wazuh: Add Active Response monitor type card */}
+      <EuiFlexItem grow={false} style={{ width: 350 }}>
+        <FormikCheckableCard
+          name="monitorTypeActiveResponse"
+          inputProps={{
+            id: 'activeResponseMonitorRadioCard',
+            label: 'Active Response',
+            checked: values.monitor_type === MONITOR_TYPE.ACTIVE_RESPONSE,
+            value: MONITOR_TYPE.ACTIVE_RESPONSE,
+            onChange: (e, field, form) => onChangeDefinition(e, form),
+            children: activeResponseDescription,
+            'data-test-subj': 'activeResponseMonitorRadioCard',
+          }}
+        />
+      </EuiFlexItem>
     </EuiFlexGrid>
   </>
 );

--- a/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
@@ -283,6 +283,60 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="euiFlexItem euiFlexItem--flexGrowZero"
+      style="width:350px"
+    >
+      <div
+        class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--hasBorder euiPanel--flexGrowZero euiSplitPanel euiSplitPanel--row euiCheckableCard eui-fullHeight"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--subdued euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiPanel--isClickable euiSplitPanel__inner"
+        >
+          <div
+            class="euiRadio euiRadio--noLabel"
+            data-test-subj="activeResponseMonitorRadioCard"
+          >
+            <input
+              class="euiRadio__input"
+              id="activeResponseMonitorRadioCard"
+              name="monitorTypeActiveResponse"
+              type="radio"
+              value="active_response_monitor"
+            />
+            <div
+              class="euiRadio__circle"
+            />
+          </div>
+        </div>
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiSplitPanel__inner"
+        >
+          <label
+            aria-describedby="activeResponseMonitorRadioCard-details"
+            class="euiCheckableCard__label"
+            for="activeResponseMonitorRadioCard"
+          >
+            Active Response
+          </label>
+          <div
+            class="euiCheckableCard__children"
+            id="activeResponseMonitorRadioCard-details"
+          >
+            <div
+              class="euiText euiText--extraSmall"
+              style="padding-bottom:10px;padding-top:0px"
+            >
+              <div
+                class="euiTextColor euiTextColor--subdued"
+              >
+                Active Response monitors trigger active responses when documents match the trigger conditions.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>,
 ]
 `;

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -102,6 +102,7 @@ export default class CreateMonitor extends Component {
     this.onCancel = this.onCancel.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
     this.evaluateSubmission = this.evaluateSubmission.bind(this);
+    this.validateForm = this.validateForm.bind(this);
   }
 
   componentDidMount() {
@@ -142,6 +143,24 @@ export default class CreateMonitor extends Component {
       }
     }
   };
+
+  // Wazuh: Validate that Active Response monitors have at least one trigger with an AR action
+  validateForm(values) {
+    const errors = {};
+    if (values.monitor_type === MONITOR_TYPE.ACTIVE_RESPONSE) {
+      const triggerDefinitions = _.get(values, 'triggerDefinitions', []);
+      const hasActiveResponseAction = triggerDefinitions.some((trigger) =>
+        _.get(trigger, 'actions', []).some((action) =>
+          _.get(action, 'id', '').startsWith('activeResponse')
+        )
+      );
+      if (!hasActiveResponseAction) {
+        errors.noActiveResponseAction =
+          'There must be at least one trigger with an Active Response action configured.';
+      }
+    }
+    return errors;
+  }
 
   evaluateSubmission(values, formikBag) {
     const { performanceResponse } = this.props;
@@ -494,10 +513,11 @@ export default class CreateMonitor extends Component {
         <Formik
           initialValues={initialValues}
           onSubmit={this.evaluateSubmission}
+          validate={this.validateForm}
           validateOnChange={false}
           enableReinitialize={true}
         >
-          {({ values, errors, handleSubmit, isSubmitting, isValid, touched, setFieldValue }) => {
+          {({ values, errors, handleSubmit, isSubmitting, isValid, touched, setFieldValue, submitCount }) => {
             const isComposite = values.monitor_type === MONITOR_TYPE.COMPOSITE_LEVEL;
             const isPpl = values.monitor_type === MONITOR_TYPE.PPL;
 
@@ -594,6 +614,8 @@ export default class CreateMonitor extends Component {
                         {(triggerArrayHelpers) => (
                           <ConfigureTriggers
                             edit={edit}
+                            errors={errors}
+                            submitCount={submitCount}
                             triggerArrayHelpers={triggerArrayHelpers}
                             monitor={formikToMonitor(values)}
                             monitorValues={values}

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -28,6 +28,7 @@ export function formikToMonitor(values) {
 
   const monitorUiMetadata = () => {
     switch (values.monitor_type) {
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: same doc-level inputs structure
       case MONITOR_TYPE.DOC_LEVEL:
         return {
           [DOC_LEVEL_INPUT_FIELD]: formikToDocLevelQueriesUiMetadata(values),
@@ -86,6 +87,7 @@ export function formikToInputs(values) {
   switch (values.monitor_type) {
     case MONITOR_TYPE.CLUSTER_METRICS:
       return formikToClusterMetricsInput(values);
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: same doc-level inputs structure
     case MONITOR_TYPE.DOC_LEVEL:
       return formikToDocLevelInput(values);
     case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
@@ -135,6 +135,7 @@ export const prepareTriggers = ({
         triggerType = TRIGGER_TYPE.BUCKET_LEVEL;
         break;
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         triggerType = TRIGGER_TYPE.DOC_LEVEL;
         break;
       case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -40,6 +40,7 @@ export default function monitorToFormik(monitor) {
           clusterNames: inputs[0].uri.clusters || [],
           searchType: SEARCH_TYPE.CLUSTER_METRICS,
         };
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: same doc-level inputs structure
       case MONITOR_TYPE.DOC_LEVEL:
         return docLevelInputToFormik(monitor);
       case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.js
@@ -202,6 +202,7 @@ export const prepareTriggers = ({
         triggerType = TRIGGER_TYPE.BUCKET_LEVEL;
         break;
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         triggerType = TRIGGER_TYPE.DOC_LEVEL;
         break;
       case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingMonitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingMonitorToFormik.js
@@ -68,6 +68,7 @@ export default function pplAlertingMonitorToFormik(monitorIn) {
           searchType: SEARCH_TYPE.CLUSTER_METRICS,
         };
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         return docLevelInputToFormik(monitor);
       case MONITOR_TYPE.COMPOSITE_LEVEL: {
         const triggerConditions = _.get(

--- a/public/pages/CreateMonitor/containers/DataSource/DataSource.js
+++ b/public/pages/CreateMonitor/containers/DataSource/DataSource.js
@@ -38,6 +38,7 @@ class DataSource extends Component {
     const displayTimeField =
       searchType === SEARCH_TYPE.GRAPH &&
       monitor_type !== MONITOR_TYPE.DOC_LEVEL &&
+      monitor_type !== MONITOR_TYPE.ACTIVE_RESPONSE && // Wazuh: Handle Active Response monitor type
       monitor_type !== MONITOR_TYPE.CLUSTER_METRICS;
     const monitorIndexDisplay = (
       <>

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -254,6 +254,7 @@ class DefineMonitor extends Component {
         return true;
       case MONITOR_TYPE.CLUSTER_METRICS:
         return false;
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       case MONITOR_TYPE.DOC_LEVEL:
         return false;
       default:
@@ -308,6 +309,7 @@ class DefineMonitor extends Component {
     const aggregations = _.get(values, 'aggregations');
     const monitorExpressions = () => {
       switch (values.monitor_type) {
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         case MONITOR_TYPE.DOC_LEVEL:
           return <ConfigureDocumentLevelQueries errors={errors} dataTypes={dataTypes} />;
         default:
@@ -322,6 +324,7 @@ class DefineMonitor extends Component {
       switch (values.monitor_type) {
         case MONITOR_TYPE.BUCKET_LEVEL:
           return this.getBucketMonitorGraphs(aggregations, formikSnapshot, response);
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         case MONITOR_TYPE.DOC_LEVEL:
           const { index, queries } = values;
           accordionTitle = 'Preview findings and performance';
@@ -377,6 +380,7 @@ class DefineMonitor extends Component {
 
     // Cancel execution criteria
     switch (monitor_type) {
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       case MONITOR_TYPE.DOC_LEVEL:
         // Wazuh: fix conditional to only run validation for doc level graph queries
         if (searchType === SEARCH_TYPE.GRAPH) {
@@ -449,7 +453,7 @@ class DefineMonitor extends Component {
 
         // TODO FIXME: Doc level backend monitor run results don't include duration metrics. Using this for now.
         //  This returns a much longer duration than other monitors, though.
-        if (monitor_type === MONITOR_TYPE.DOC_LEVEL) {
+        if (monitor_type === MONITOR_TYPE.DOC_LEVEL || monitor_type === MONITOR_TYPE.ACTIVE_RESPONSE) { // Wazuh: Handle Active Response monitor type
           let hitsCount = 0;
           _.keys(response).forEach(
             (resultKey) => (hitsCount += _.values(performanceResponse[resultKey]).length)
@@ -532,7 +536,9 @@ class DefineMonitor extends Component {
     const { values, flyoutMode } = this.props;
     const { index, timeField } = values;
     let content;
-    const supportsTimeField = values.monitor_type !== MONITOR_TYPE.DOC_LEVEL;
+    const supportsTimeField =
+      values.monitor_type !== MONITOR_TYPE.DOC_LEVEL &&
+      values.monitor_type !== MONITOR_TYPE.ACTIVE_RESPONSE; // Wazuh: Handle Active Response monitor type
     if (index.length) {
       content =
         _.isEmpty(timeField) && supportsTimeField

--- a/public/pages/CreateMonitor/containers/DefineMonitor/utils/searchRequests.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/utils/searchRequests.js
@@ -18,6 +18,7 @@ export const buildRequest = (values, uiGraphQuery = true) =>
 
 function buildQuerySearchRequest(values) {
   switch (values.monitor_type) {
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
     case MONITOR_TYPE.DOC_LEVEL:
       return formikToDocLevelInput(values);
     default:
@@ -29,6 +30,7 @@ function buildQuerySearchRequest(values) {
 
 function buildGraphSearchRequest(values, uiGraphQuery) {
   switch (values.monitor_type) {
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
     case MONITOR_TYPE.DOC_LEVEL:
       return formikToDocLevelInput(values);
     default:

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -11,7 +11,7 @@ import { EuiHealth, EuiHighlight } from '@elastic/eui';
 import { FormikComboBox } from '../../../../components/FormControls';
 import { validateIndex, hasError, isInvalid } from '../../../../utils/validate';
 import { canAppendWildcard, createReasonableWait, getMatchedOptions } from './utils/helpers';
-import { MONITOR_TYPE } from '../../../../utils/constants';
+import { ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN, MONITOR_TYPE } from '../../../../utils/constants';
 import CrossClusterConfiguration from '../../components/CrossClusterConfigurations/containers';
 import {
   getDataSourceQueryObj,
@@ -65,14 +65,19 @@ class MonitorIndex extends React.Component {
     this.onFetch = this.onFetch.bind(this);
   }
 
+  getInitialSearchQuery() {
+    return this.props.monitorType === MONITOR_TYPE.ACTIVE_RESPONSE
+      ? ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN
+      : '';
+  }
+
   componentDidMount() {
-    // Simulate initial load.
-    this.onSearchChange('');
+    this.onSearchChange(this.getInitialSearchQuery());
   }
 
   componentDidUpdate(prevProps) {
     if (isDataSourceChanged(prevProps, this.props)) {
-      this.onSearchChange('');
+      this.onSearchChange(this.getInitialSearchQuery());
     }
   }
 
@@ -246,7 +251,7 @@ class MonitorIndex extends React.Component {
       exactMatchedAliases,
     } = this.state;
 
-    const { visibleOptions } = getMatchedOptions(
+    let { visibleOptions } = getMatchedOptions(
       allIndices, //all indices
       partialMatchedIndices,
       exactMatchedIndices,
@@ -256,9 +261,18 @@ class MonitorIndex extends React.Component {
       false //isIncludingSystemIndices
     );
 
+    // Wazuh: restrict index options to findings indices for Active Response monitors
+    if (this.props.monitorType === MONITOR_TYPE.ACTIVE_RESPONSE) {
+      const isFindingsIndex = (o) => o.label.startsWith('wazuh-findings');
+      visibleOptions = visibleOptions
+        .map((group) => ({ ...group, options: group.options.filter(isFindingsIndex) }))
+        .filter((group) => group.options.length > 0);
+    }
+
     let supportMultipleIndices = true;
     let supportsCrossClusterMonitoring = false;
     switch (this.props.monitorType) {
+      case MONITOR_TYPE.ACTIVE_RESPONSE:
       case MONITOR_TYPE.DOC_LEVEL:
         supportMultipleIndices = false;
         supportsCrossClusterMonitoring = false;

--- a/public/pages/CreateTrigger/components/Action/EnhancedAction.js
+++ b/public/pages/CreateTrigger/components/Action/EnhancedAction.js
@@ -178,6 +178,7 @@ const Action = ({
                 onFocus: refreshDestinations,
                 singleSelection: { asPlainText: true },
                 isClearable: false,
+                'data-test-subj': 'channelComboBox',
                 renderOption: (option) => (
                   <div style={{ lineHeight: '1' }}>
                     <EuiText size="s">

--- a/public/pages/CreateTrigger/components/Action/EnhancedAction.js
+++ b/public/pages/CreateTrigger/components/Action/EnhancedAction.js
@@ -179,14 +179,21 @@ const Action = ({
                 singleSelection: { asPlainText: true },
                 isClearable: false,
                 renderOption: (option) => (
-                  <React.Fragment>
-                    <EuiText size="s">{option.label}</EuiText>
-                    <EuiText size="xs" color="subdued">
-                      {option.description}
+                  <div style={{ lineHeight: '1' }}>
+                    <EuiText size="s">
+                      {option.label}
                     </EuiText>
-                  </React.Fragment>
+                    {option.description && (
+                      <EuiText
+                        size="xs"
+                        color="subdued"
+                      >
+                        {option.description}
+                      </EuiText>
+                    )}
+                  </div>
                 ),
-                rowHeight: 30,
+                rowHeight: 46,
                 isLoading: !flyoutMode && loadingDestinations,
               }}
             />

--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -155,6 +155,7 @@ export default function Message(
       defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_ALERT;
       break;
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_EXECUTION;
       break;
     default:
@@ -176,6 +177,7 @@ export default function Message(
       actionableAlertsSelections = _.get(values, actionableAlertsSelectionsPath);
       break;
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       displayActionableAlertsOptions = false;
       displayThrottlingSettings = false;
       actionableAlertsSelections = [];

--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -141,7 +141,9 @@ export default function Message(
   const onDisplayPreviewChange = (e) => setDisplayPreview(e.target.checked);
   const monitorType = _.get(context, 'ctx.monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
   const editableActionExecutionPolicy =
-    monitorType === MONITOR_TYPE.BUCKET_LEVEL || monitorType === MONITOR_TYPE.DOC_LEVEL;
+    monitorType === MONITOR_TYPE.BUCKET_LEVEL ||
+    monitorType === MONITOR_TYPE.DOC_LEVEL ||
+    monitorType === MONITOR_TYPE.ACTIVE_RESPONSE;
 
   const actionPath = `${fieldPath}actions.${index}`;
   const actionExecutionPolicyPath = editableActionExecutionPolicy

--- a/public/pages/CreateTrigger/components/Action/actions/MessagePpl.js
+++ b/public/pages/CreateTrigger/components/Action/actions/MessagePpl.js
@@ -141,7 +141,7 @@ export default function MessagePpl(
   const onDisplayPreviewChange = (e) => setDisplayPreview(e.target.checked);
   const monitorType = _.get(context, 'ctx.monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
   const editableActionExecutionPolicy =
-    monitorType === MONITOR_TYPE.BUCKET_LEVEL || monitorType === MONITOR_TYPE.DOC_LEVEL;
+    monitorType === MONITOR_TYPE.BUCKET_LEVEL || monitorType === MONITOR_TYPE.DOC_LEVEL || monitorType === MONITOR_TYPE.ACTIVE_RESPONSE; // Wazuh: Handle Active Response monitor type
 
   const actionPath = `${fieldPath}actions.${index}`;
   const actionExecutionPolicyPath = editableActionExecutionPolicy
@@ -155,6 +155,7 @@ export default function MessagePpl(
       defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_ALERT;
       break;
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_EXECUTION;
       break;
     default:
@@ -176,6 +177,7 @@ export default function MessagePpl(
       actionableAlertsSelections = _.get(values, actionableAlertsSelectionsPath);
       break;
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       displayActionableAlertsOptions = false;
       displayThrottlingSettings = false;
       actionableAlertsSelections = [];

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/EnhancedActionEmptyPrompt.js
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/EnhancedActionEmptyPrompt.js
@@ -28,23 +28,11 @@ const ActionEmptyPrompt = ({
       style={{ maxWidth: '45em' }}
       body={
         <EuiText size="s">
-          <p>{hasDestinations ? actionEmptyText : destinationEmptyText}</p>
+          <p>{actionEmptyText}</p>
         </EuiText>
       }
       actions={
-        hasDestinations ? (
           <AddActionButton {...{ arrayHelpers, flyoutMode, onPostAdd, numActions }} />
-        ) : (
-          <EuiSmallButton
-            fill
-            disabled={!hasNotificationPlugin}
-            iconType="popout"
-            iconSide="right"
-            onClick={() => window.open(getManageChannelsUrl())}
-          >
-            Manage channels
-          </EuiSmallButton>
-        )
       }
     />
   );

--- a/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
@@ -53,14 +53,16 @@ const AddActionButton = ({
 
   return flyoutMode ? (
     <EuiPanel paddingSize="none">
-      <EuiSmallButtonEmpty
-        onClick={onClickNotification}
-        iconType="plusInCircle"
-        className="add-action-button__flyout-button"
-      >
-        {buttonNotificationText}
-      </EuiSmallButtonEmpty>
-      {monitorType === MONITOR_TYPE.DOC_LEVEL && (
+      {monitorType !== MONITOR_TYPE.ACTIVE_RESPONSE && (
+        <EuiSmallButtonEmpty
+          onClick={onClickNotification}
+          iconType="plusInCircle"
+          className="add-action-button__flyout-button"
+        >
+          {buttonNotificationText}
+        </EuiSmallButtonEmpty>
+      )}
+      {monitorType === MONITOR_TYPE.ACTIVE_RESPONSE && (
         <EuiSmallButtonEmpty
           onClick={onClickActiveResponse}
           iconType="plusInCircle"
@@ -81,10 +83,12 @@ const AddActionButton = ({
           justifyContent: 'center',
         }}
       >
-        <EuiButton fill={false} size={'s'} onClick={onClickNotification}>
-          {buttonNotificationText}
-        </EuiButton>
-        {monitorType === MONITOR_TYPE.DOC_LEVEL && (
+        {monitorType !== MONITOR_TYPE.ACTIVE_RESPONSE && (
+          <EuiButton fill={false} size={'s'} onClick={onClickNotification}>
+            {buttonNotificationText}
+          </EuiButton>
+        )}
+        {monitorType === MONITOR_TYPE.ACTIVE_RESPONSE && (
           <EuiButton fill={false} size={'s'} onClick={onClickActiveResponse}>
             {buttonActiveResponseText}
           </EuiButton>

--- a/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
@@ -53,15 +53,13 @@ const AddActionButton = ({
 
   return flyoutMode ? (
     <EuiPanel paddingSize="none">
-      {monitorType !== MONITOR_TYPE.ACTIVE_RESPONSE && (
-        <EuiSmallButtonEmpty
-          onClick={onClickNotification}
-          iconType="plusInCircle"
-          className="add-action-button__flyout-button"
-        >
-          {buttonNotificationText}
-        </EuiSmallButtonEmpty>
-      )}
+      <EuiSmallButtonEmpty
+        onClick={onClickNotification}
+        iconType="plusInCircle"
+        className="add-action-button__flyout-button"
+      >
+        {buttonNotificationText}
+      </EuiSmallButtonEmpty>
       {monitorType === MONITOR_TYPE.ACTIVE_RESPONSE && (
         <EuiSmallButtonEmpty
           onClick={onClickActiveResponse}
@@ -83,11 +81,9 @@ const AddActionButton = ({
           justifyContent: 'center',
         }}
       >
-        {monitorType !== MONITOR_TYPE.ACTIVE_RESPONSE && (
-          <EuiButton fill={false} size={'s'} onClick={onClickNotification}>
-            {buttonNotificationText}
-          </EuiButton>
-        )}
+        <EuiButton fill={false} size={'s'} onClick={onClickNotification}>
+          {buttonNotificationText}
+        </EuiButton>
         {monitorType === MONITOR_TYPE.ACTIVE_RESPONSE && (
           <EuiButton fill={false} size={'s'} onClick={onClickActiveResponse}>
             {buttonActiveResponseText}

--- a/public/pages/CreateTrigger/components/AddActionButton/styles.scss
+++ b/public/pages/CreateTrigger/components/AddActionButton/styles.scss
@@ -11,7 +11,8 @@
   }
 }
 
-// Wazuh: improve spacing of combo box options list
-.euiComboBoxOptionsList .euiComboBoxTitle {
+// Wazuh: improve spacing of channel combo box group titles
+// option list are virtually rendered in a portal, so we need to target them this way
+[data-test-subj~='channelComboBox-optionsList'] .euiComboBoxTitle {
   padding-top: 14px;
 }

--- a/public/pages/CreateTrigger/components/AddActionButton/styles.scss
+++ b/public/pages/CreateTrigger/components/AddActionButton/styles.scss
@@ -10,3 +10,8 @@
     min-height: 50px;
   }
 }
+
+// Wazuh: improve spacing of combo box options list
+.euiComboBoxOptionsList .euiComboBoxTitle {
+  padding-top: 14px;
+}

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -296,6 +296,7 @@ class ConfigureActions extends React.Component {
         _.set(testTrigger, `${TRIGGER_TYPE.BUCKET_LEVEL}.condition`, condition);
         break;
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         action = _.get(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.actions[${index}]`);
         condition = {
           ..._.get(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.condition`),

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
@@ -243,6 +243,7 @@ class ConfigureActionsPpl extends React.Component {
         _.set(testTrigger, `${TRIGGER_TYPE.BUCKET_LEVEL}.condition`, condition);
         break;
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         action = _.get(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.actions[${index}]`);
         condition = {
           ..._.get(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.condition`),

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -379,6 +379,7 @@ class ConfigureTriggers extends React.Component {
       switch (monitorValues.monitor_type) {
         case MONITOR_TYPE.BUCKET_LEVEL:
           return this.renderDefineBucketLevelTrigger(arrayHelpers, index);
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Add Active Response monitor type
         case MONITOR_TYPE.DOC_LEVEL:
           return this.renderDefineDocumentLevelTrigger(arrayHelpers, index);
         case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import {
+  EuiCallOut,
   EuiHorizontalRule,
   EuiSpacer,
   EuiBadge,
@@ -437,13 +438,15 @@ class ConfigureTriggers extends React.Component {
   };
 
   render() {
-    const { triggerArrayHelpers, triggerValues, flyoutMode, monitorValues } = this.props;
+    const { triggerArrayHelpers, triggerValues, flyoutMode, monitorValues, errors, submitCount } = this.props;
     const { ContentPanelStructure } = this.state;
     const numOfTriggers = _.get(triggerValues, 'triggerDefinitions', []).length;
     const displayAddTriggerButton = numOfTriggers > 0;
     const disableAddTriggerButton = numOfTriggers >= MAX_TRIGGERS;
     const monitorType = monitorValues.monitor_type;
     const isComposite = monitorType === MONITOR_TYPE.COMPOSITE_LEVEL;
+
+    const activeResponseActionError = submitCount > 0 && errors?.noActiveResponseAction;
 
     return (
       <ContentPanelStructure
@@ -458,6 +461,17 @@ class ConfigureTriggers extends React.Component {
         bodyStyles={{ paddingLeft: '0px', padding: '10px' }}
         horizontalRuleClassName={'accordion-horizontal-rule'}
       >
+        {activeResponseActionError && (
+          <div id="noActiveResponseAction" tabIndex={-1} style={{ outline: 'none' }}>
+            <EuiCallOut
+              title={activeResponseActionError}
+              color="danger"
+              iconType="alert"
+              size="s"
+            />
+            <EuiSpacer size="s" />
+          </div>
+        )}
         {this.renderTriggers(triggerArrayHelpers)}
         {flyoutMode && !disableAddTriggerButton && (
           <AddTriggerButton

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -34,6 +34,7 @@ export function formikToTriggerDefinition(values, monitorUiMetadata) {
     case MONITOR_TYPE.BUCKET_LEVEL:
       return formikToBucketLevelTrigger(values, monitorUiMetadata);
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       return formikToDocumentLevelTrigger(values, monitorUiMetadata);
     case MONITOR_TYPE.COMPOSITE_LEVEL:
       return formikToCompositeLevelTrigger(values, monitorUiMetadata);
@@ -284,6 +285,7 @@ export function formikToTriggerUiMetadata(values, monitorUiMetadata) {
       return bucketLevelTriggersUiMetadata;
 
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       const docLevelTriggersUiMetadata = {};
       _.get(values, 'triggerDefinitions', []).forEach((trigger) => {
         const triggerMetadata = _.get(trigger, 'triggerConditions', []).map((condition) => ({

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
@@ -34,6 +34,7 @@ export function triggerDefinitionToFormik(trigger, monitor) {
     case MONITOR_TYPE.BUCKET_LEVEL:
       return bucketLevelTriggerToFormik(trigger, monitor);
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       return documentLevelTriggerToFormik(trigger, monitor);
     case MONITOR_TYPE.COMPOSITE_LEVEL:
       return compositeTriggerToFormik(trigger, monitor);

--- a/public/pages/CreateTrigger/utils/helper.js
+++ b/public/pages/CreateTrigger/utils/helper.js
@@ -62,6 +62,7 @@ export const getDefaultScript = (monitorValues) => {
     case MONITOR_TYPE.CLUSTER_METRICS:
       const apiType = _.get(monitorValues, 'uri.api_type');
       return _.get(API_TYPES, `${apiType}.defaultCondition`, DEFAULT_CLUSTER_METRICS_SCRIPT);
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Add Active Response monitor type
     case MONITOR_TYPE.DOC_LEVEL:
       return FORMIK_INITIAL_DOC_LEVEL_SCRIPT;
     default:

--- a/public/pages/CreateTrigger/utils/helper.test.js
+++ b/public/pages/CreateTrigger/utils/helper.test.js
@@ -34,6 +34,12 @@ describe('CreateTrigger/utils/helper', () => {
       expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_DOC_LEVEL_SCRIPT);
     });
 
+    // Wazuh: Add test case for ACTIVE_RESPONSE monitor type
+    test(`when monitor_type is ${MONITOR_TYPE.ACTIVE_RESPONSE}`, () => {
+      const monitorValues = { monitor_type: MONITOR_TYPE.ACTIVE_RESPONSE };
+      expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_DOC_LEVEL_SCRIPT);
+    });
+
     test(`when monitor_type is ${MONITOR_TYPE.QUERY_LEVEL}`, () => {
       const monitorValues = { monitor_type: MONITOR_TYPE.QUERY_LEVEL };
       expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_TRIGGER_VALUES.script);

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
@@ -270,6 +270,7 @@ export default class AcknowledgeAlertsModal extends Component {
         case MONITOR_TYPE.QUERY_LEVEL:
         case MONITOR_TYPE.CLUSTER_METRICS:
         case MONITOR_TYPE.DOC_LEVEL:
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
           return `${item.id}-${item.version}`;
         case MONITOR_TYPE.BUCKET_LEVEL:
           return item.id;
@@ -300,6 +301,7 @@ export default class AcknowledgeAlertsModal extends Component {
           columns = insertGroupByColumn(groupBy);
           break;
         case MONITOR_TYPE.DOC_LEVEL:
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
           columns = _.cloneDeep(queryColumns);
           columns.splice(
             0,

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -50,6 +50,7 @@ const DashboardControls = ({
   let supportedStateOptions = stateOptions;
   switch (monitorType) {
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       const supportedStates = [ALERT_STATE.ACKNOWLEDGED, ALERT_STATE.ACTIVE, ALERT_STATE.ERROR];
       supportedStateOptions = stateOptions.filter((state) =>
         _.includes(supportedStates, state.value)

--- a/public/pages/Dashboard/containers/DashboardClassic.js
+++ b/public/pages/Dashboard/containers/DashboardClassic.js
@@ -483,6 +483,7 @@ export default class DashboardClassic extends Component {
           columns.push(CLUSTER_METRICS_CROSS_CLUSTER_ALERT_TABLE_COLUMN);
           break;
         case MONITOR_TYPE.DOC_LEVEL:
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
           columns = _.cloneDeep(queryColumns);
           columns.splice(
             0,

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -50,6 +50,8 @@ function getMonitorLevelType(monitorType) {
       return 'Per bucket monitor';
     case MONITOR_TYPE.CLUSTER_METRICS:
       return 'Per cluster metrics monitor';
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Add Active Response monitor type
+      return 'Active Response monitor';
     case MONITOR_TYPE.DOC_LEVEL:
       return 'Per document monitor';
     case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/MonitorDetails/containers/MonitorDetailsV1.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetailsV1.js
@@ -246,6 +246,7 @@ export default class MonitorDetailsV1 extends Component {
     let query = { ifSeqNo, ifPrimaryTerm };
     switch (monitor.monitor_type) {
       case MONITOR_TYPE.DOC_LEVEL:
+      case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
         query = {};
         break;
     }
@@ -473,7 +474,7 @@ export default class MonitorDetailsV1 extends Component {
       );
     }
 
-    const displayTableTabs = [MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(
+    const displayTableTabs = [MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL, MONITOR_TYPE.ACTIVE_RESPONSE].includes(
       monitor.monitor_type
     );
 

--- a/public/pages/MonitorDetails/containers/MonitorDetailsV2.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetailsV2.js
@@ -662,7 +662,7 @@ export default class MonitorDetailsV2 extends Component {
       );
     }
 
-    const displayTableTabs = [MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(
+    const displayTableTabs = [MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL, MONITOR_TYPE.ACTIVE_RESPONSE].includes(
       displayMonitor.monitor_type
     );
 

--- a/public/pages/MonitorDetails/containers/Triggers/Triggers.js
+++ b/public/pages/MonitorDetails/containers/Triggers/Triggers.js
@@ -37,6 +37,7 @@ export function getUnwrappedTriggers(monitor) {
           unwrappedTrigger = trigger[TRIGGER_TYPE.BUCKET_LEVEL];
           break;
         case MONITOR_TYPE.DOC_LEVEL:
+        case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
           unwrappedTrigger = trigger[TRIGGER_TYPE.DOC_LEVEL];
           break;
         case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/Monitors/containers/Monitors/utils/helpers.js
+++ b/public/pages/Monitors/containers/Monitors/utils/helpers.js
@@ -35,6 +35,8 @@ export function getItemLevelType(itemType) {
       return 'Per bucket';
     case MONITOR_TYPE.CLUSTER_METRICS:
       return 'Per cluster metrics';
+    case MONITOR_TYPE.ACTIVE_RESPONSE:
+      return 'Active Response';
     case MONITOR_TYPE.DOC_LEVEL:
       return 'Per document';
     case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -35,7 +35,11 @@ export const MONITOR_TYPE = {
   DOC_LEVEL: 'doc_level_monitor',
   COMPOSITE_LEVEL: 'composite',
   PPL: 'ppl_monitor',
+  ACTIVE_RESPONSE: 'active_response_monitor', // Wazuh
 };
+
+// Wazuh: Index pattern for findings indices used by Active Response monitors
+export const ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN = 'wazuh-findings*';
 
 export const DESTINATION_ACTIONS = {
   UPDATE_DESTINATION: 'update-destination',
@@ -107,6 +111,7 @@ export const monitorTypesForComposition = new Set([
   MONITOR_TYPE.BUCKET_LEVEL,
   MONITOR_TYPE.DOC_LEVEL,
   MONITOR_TYPE.QUERY_LEVEL,
+  MONITOR_TYPE.ACTIVE_RESPONSE, // Wazuh
 ]);
 
 export const PLUGIN_AUGMENTATION_ENABLE_SETTING = 'visualization:enablePluginAugmentation';

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -35,6 +35,7 @@ export const validateActionName = (monitor, trigger) => (value) => {
       actions = _.get(trigger, `${TRIGGER_TYPE.BUCKET_LEVEL}.actions`, []);
       break;
     case MONITOR_TYPE.DOC_LEVEL:
+    case MONITOR_TYPE.ACTIVE_RESPONSE: // Wazuh: Handle Active Response monitor type
       actions = _.get(trigger, `${TRIGGER_TYPE.DOC_LEVEL}.actions`, []);
       break;
   }


### PR DESCRIPTION
### Description

Adds "Active Response" as a new monitor type in the dashboard. It is distinct from "Per document", and is expected to be a native type in the indexer (`active_response_monitor`).

**Behavioral differences from Per document:**
- Active Response monitors only allow active response trigger actions: the "Add notification" button is hidden.
- Per document monitors no longer allow active response trigger actions: the "Add active response" button is hidden.
- The index selector for Active Response monitors is restricted to `wazuh-findings*` indices only.


### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-alerting/issues/31

### Test

- **Create an Active Response monitor with active response action**
   - Go to Create Monitor => select "Active Response" type.
   - Configure queries and add a trigger with an active response action.
   - Verify the monitor can be saved succesfully.

- **Create a Per document monitor with multiple actions**
   - Go to Create Monitor => select "Per document" type.
     - Configure queries and add a trigger with an active response action and a notification action.
   - Verify the monitor can be saved succesfully.

- **Edit an Active Response monitor**
   - Open the monitor created in step 1.
   - Confirm the monitor type selector shows "Active Response" pre selected.
   - Make changes.
   - Verify changes are applied correctly.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
