### PR TITLE
Remove duplicate action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 ### Fixed
 
 - Fixed request execution in Extraction Query Editor [#24](https://github.com/wazuh/wazuh-dashboard-alerting/pull/24)
+- Fixed duplicated button in Monitors list [#73](https://github.com/wazuh/wazuh-dashboard-alerting/pull/73)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,3 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 ### Fixed
 
 - Fixed request execution in Extraction Query Editor [#24](https://github.com/wazuh/wazuh-dashboard-alerting/pull/24)
-- Fixed duplicated action buttons in monitors tab [#73](https://github.com/wazuh/wazuh-dashboard-alerting/pull/73)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 ### Fixed
 
 - Fixed request execution in Extraction Query Editor [#24](https://github.com/wazuh/wazuh-dashboard-alerting/pull/24)
+- Fixed duplicated action buttons in monitors tab [#73](https://github.com/wazuh/wazuh-dashboard-alerting/pull/73)

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -526,9 +526,8 @@ export default class Monitors extends Component {
 
     return (
       <>
-        {/* Wazuh: commented out actions property from ContentPanel since it duplicates monitorActions when useUpdatedUx is false */}
         <ContentPanel
-          // actions={useUpdatedUx ? undefined : monitorActions}
+          actions={useUpdatedUx ? undefined : monitorActions}
           bodyStyles={{ padding: 'initial' }}
           title={useUpdatedUx ? undefined : 'Monitors'}
           panelOptions={{ hideTitleBorder: useUpdatedUx }}
@@ -559,7 +558,7 @@ export default class Monitors extends Component {
             onSearchChange={this.onSearchChange}
             onStateChange={this.onMonitorStateChange}
             onPageClick={this.onPageClick}
-            monitorActions={useUpdatedUx ? null : monitorActions}
+            monitorActions={useUpdatedUx ? monitorActions : null}
           />
 
           {showAcknowledgeModal && (

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -526,8 +526,9 @@ export default class Monitors extends Component {
 
     return (
       <>
+        {/* Wazuh: commented out actions property from ContentPanel since it duplicates monitorActions when useUpdatedUx is false */}
         <ContentPanel
-          actions={useUpdatedUx ? undefined : monitorActions}
+          // actions={useUpdatedUx ? undefined : monitorActions}
           bodyStyles={{ padding: 'initial' }}
           title={useUpdatedUx ? undefined : 'Monitors'}
           panelOptions={{ hideTitleBorder: useUpdatedUx }}


### PR DESCRIPTION
### Description
The "Actions" and "+ Create monitor" buttons were appearing twice in the Monitors view. Removed the duplicate set of buttons from the title area, keeping only the single instance alongside the search and state filter controls.
 
### Issues Resolved
- *Closes:* https://github.com/wazuh/wazuh-dashboard-alerting/issues/71

### Evidence

<img width="1069" height="381" alt="image" src="https://github.com/user-attachments/assets/53b55fac-18e3-45a2-ada2-992e538c738e" />

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 