### PR TITLE
Updates GitHub Actions runner to Ubuntu 26.04

### DIFF
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -38,7 +38,7 @@ jobs:
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

This PR updates the Ubuntu version used into GHA workflows to latest LTS version, 26.04

### Issues Resolved

- https://github.com/wazuh/wazuh/issues/35755
