### PR TITLE
Hide monitors created by security analytics plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 - Changed category in the side menu to `Explore` [#4](https://github.com/wazuh/wazuh-dashboard-alerting/pull/4)
 - Support `date` and `ip` type fields in document level queries [#22](https://github.com/wazuh/wazuh-dashboard-alerting/pull/22)
 - Hide "Add active response" button for all monitor types except "Per document monitor" / Do not auto-load notification form when adding a trigger. [#18](https://github.com/wazuh/wazuh-dashboard-alerting/pull/18)
+- Hide `security_analytics` owned monitors in table [#85](https://github.com/wazuh/wazuh-dashboard-alerting/pull/85)
 
 ### Fixed
 

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
@@ -140,6 +140,10 @@ describe('whereHelpers', () => {
           text: 'is null',
           value: 'is_null',
         },
+        {
+          text: 'is not null',
+          value: 'is_not_null',
+        }
       ]);
     });
   });

--- a/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
@@ -91,6 +91,7 @@ exports[`CreateMonitor renders 1`] = `
       }
     }
     onSubmit={[Function]}
+    validate={[Function]}
     validateOnChange={false}
   >
     <Component />

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -96,7 +96,7 @@ describe('MonitorIndex', () => {
     const wrapper = getMountWrapper();
 
     expect(await wrapper.find(MonitorIndex).instance().handleQueryAliases('*:')).toEqual([]);
-    expect(await wrapper.find(MonitorIndex).instance().handleQueryIndices('*:')).toEqual([]);
+    expect((await wrapper.find(MonitorIndex).instance().handleQueryIndices('*:')).indices).toEqual([]);
   });
 
   test('returns empty array for data.ok = false', async () => {
@@ -104,7 +104,7 @@ describe('MonitorIndex', () => {
     const wrapper = getMountWrapper();
 
     expect(await wrapper.find(MonitorIndex).instance().handleQueryAliases('random')).toEqual([]);
-    expect(await wrapper.find(MonitorIndex).instance().handleQueryIndices('random')).toEqual([]);
+    expect((await wrapper.find(MonitorIndex).instance().handleQueryIndices('random')).indices).toEqual([]);
   });
   //
   test('returns indices/aliases', async () => {
@@ -117,7 +117,7 @@ describe('MonitorIndex', () => {
     expect(await wrapper.find(MonitorIndex).instance().handleQueryAliases('l')).toEqual([
       { label: 'logstash', index: 'logstash-0' },
     ]);
-    expect(await wrapper.find(MonitorIndex).instance().handleQueryIndices('l')).toEqual([
+    expect((await wrapper.find(MonitorIndex).instance().handleQueryIndices('l')).indices).toEqual([
       { health: 'green', status: 'open', label: 'logstash-0' },
     ]);
   });

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -28,6 +28,7 @@ import {
 import { getUseUpdatedUx } from '../../../../services';
 
 const MAX_MONITOR_COUNT = 1000;
+export const EXCLUDED_OWNER = 'security_analytics'; // Wazuh: exclude monitors owned by security_analytics
 
 // TODO: Abstract out a Table component to be used in both Dashboard and Monitors
 
@@ -163,7 +164,7 @@ export default class Monitors extends Component {
     this.setState({ loadingMonitors: true });
     try {
       const dataSourceId = getDataSourceId();
-      const params = { from, size, search, sortField, sortDirection, state, dataSourceId };
+      const params = { from, size, search, sortField, sortDirection, state, dataSourceId, excludeOwner: EXCLUDED_OWNER };
       const queryParamsString = queryString.stringify(params);
       const { httpClient, history } = this.props;
       history.replace({ ...this.props.location, search: queryParamsString });

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -36,20 +36,7 @@ exports[`Monitors renders 1`] = `
   >
     <MonitorControls
       activePage={0}
-      monitorActions={
-        <MonitorActions
-          hasMonitors={false}
-          isDeleteDisabled={true}
-          isDisableDisabled={true}
-          isEditDisabled={true}
-          isEnableDisabled={true}
-          onBulkAcknowledge={[Function]}
-          onBulkDelete={[Function]}
-          onBulkDisable={[Function]}
-          onBulkEnable={[Function]}
-          onClickEdit={[Function]}
-        />
-      }
+      monitorActions={null}
       onPageClick={[Function]}
       onSearchChange={[Function]}
       onStateChange={[Function]}

--- a/server/routes/monitors.js
+++ b/server/routes/monitors.js
@@ -17,6 +17,7 @@ export default function (services, router, dataSourceEnabled) {
     sortDirection: schema.string(),
     state: schema.string(),
     monitorIds: schema.maybe(schema.any()),
+    excludeOwner: schema.maybe(schema.string()), // Wazuh: param to optionally exclude monitors by owner
   };
 
   router.get(

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -262,7 +262,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getMonitors = async (context, req, res) => {
     try {
-      const { from, size, search, sortDirection, sortField, state, monitorIds } = req.query;
+      const { from, size, search, sortDirection, sortField, state, monitorIds, excludeOwner } = req.query;
 
       let must = { match_all: {} };
       if (search.trim()) {
@@ -318,6 +318,13 @@ export default class MonitorService extends MDSEnabledClientService {
               should,
               minimum_should_match: state !== 'all' ? 1 : 0,
               must: mustList,
+              // Wazuh: optionally exclude monitors by owner
+              ...(excludeOwner && {
+                must_not: [
+                  { term: { 'monitor.owner': excludeOwner } },
+                  { term: { 'workflow.owner': excludeOwner } },
+                ],
+              }),
             },
           },
           aggregations: {


### PR DESCRIPTION
### Description
- Include filter to exclude monitors created by security analytics plugin in monitors table.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-alerting/issues/83

### Evidence

<img width="2940" height="1522" alt="image" src="https://github.com/user-attachments/assets/a0f7a70e-c41d-451d-83a2-aade24fc6e6a" />


### Test

- Go to `Alerting > Monitors` and:
  - Verify no security analytics owned monitors are visible.
  - Create a monitor and verify it can be seen. 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
