### PR TITLE
Hide Destinations tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 - Support `date` and `ip` type fields in document level queries [#22](https://github.com/wazuh/wazuh-dashboard-alerting/pull/22)
 - Hide "Add active response" button for all monitor types except "Per document monitor" / Do not auto-load notification form when adding a trigger. [#18](https://github.com/wazuh/wazuh-dashboard-alerting/pull/18)
 - Hide `security_analytics` owned monitors in table [#85](https://github.com/wazuh/wazuh-dashboard-alerting/pull/85)
+- Hide `Destinations` tab [#88](https://github.com/wazuh/wazuh-dashboard-alerting/pull/88)
 
 ### Fixed
 

--- a/public/pages/Home/Home.js
+++ b/public/pages/Home/Home.js
@@ -36,11 +36,12 @@ export default class Home extends Component {
         name: 'Monitors',
         route: 'monitors',
       },
-      {
-        id: 'destinations',
-        name: 'Destinations',
-        route: 'destinations',
-      },
+      // Wazuh development: Destinations tab is currently hidden because it is deprecated.
+      // {
+      //   id: 'destinations',
+      //   name: 'Destinations',
+      //   route: 'destinations',
+      // },
     ];
   }
 


### PR DESCRIPTION
### Description
Hide `Destinations` tab, because it's deprecated.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-alerting/issues/87

### Evidence

<img width="1295" height="680" alt="Screenshot 2026-05-20 at 12 28 27 PM" src="https://github.com/user-attachments/assets/b50209d7-7936-44c3-b233-9a60ec4a5298" />

 
### Test

- Go to `Explore` > `Alerting` and verify that `Destinations` tab is hidden.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
