### PR TITLE
Hide document findings tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Wazuh dashboard alerting plugin will be documented in
 - Support `date` and `ip` type fields in document level queries [#22](https://github.com/wazuh/wazuh-dashboard-alerting/pull/22)
 - Hide "Add active response" button for all monitor types except "Per document monitor" / Do not auto-load notification form when adding a trigger. [#18](https://github.com/wazuh/wazuh-dashboard-alerting/pull/18)
 - Hide `security_analytics` owned monitors in table [#85](https://github.com/wazuh/wazuh-dashboard-alerting/pull/85)
+- Hide `Document findings` tab in Active Response and Per document monitor details [#89](https://github.com/wazuh/wazuh-dashboard-alerting/pull/89)
 
 ### Fixed
 

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -514,7 +514,8 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     const { tabId } = this.state;
     const tabs = [
       { ...TABLE_TAB_IDS.ALERTS, content: this.renderAlertsTable() },
-      { ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() },
+      // Wazuh: Wazuh: deprecated `Document findings` tab
+      // { ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() },
     ];
     return tabs.map((tab, index) => (
       <EuiTab

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -517,6 +517,9 @@ export default class AlertsDashboardFlyoutComponent extends Component {
       // Wazuh: Wazuh: deprecated `Document findings` tab
       // { ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() },
     ];
+
+    if (tabs.length < 2) return null; // Wazuh: hide tabs when there are less than 2
+
     return tabs.map((tab, index) => (
       <EuiTab
         key={`${tab.id}${index}`}

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -514,7 +514,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     const { tabId } = this.state;
     const tabs = [
       { ...TABLE_TAB_IDS.ALERTS, content: this.renderAlertsTable() },
-      // Wazuh: Wazuh: deprecated `Document findings` tab
+      // Wazuh: deprecated `Document findings` tab
       // { ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() },
     ];
 

--- a/public/pages/MonitorDetails/containers/MonitorDetailsV1.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetailsV1.js
@@ -403,9 +403,10 @@ export default class MonitorDetailsV1 extends Component {
     const { tabId, monitor } = this.state;
     const tabs = [{ ...TABLE_TAB_IDS.ALERTS, content: this.renderAlertsTable() }];
 
-    if (monitor.monitor_type !== MONITOR_TYPE.COMPOSITE_LEVEL) {
-      tabs.push({ ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() });
-    }
+    // Wazuh: deprecated `Document findings` tab
+    // if (monitor.monitor_type !== MONITOR_TYPE.COMPOSITE_LEVEL) {
+    //   tabs.push({ ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() });
+    // }
 
     return tabs.map((tab, index) => (
       <EuiTab

--- a/public/pages/MonitorDetails/containers/MonitorDetailsV1.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetailsV1.js
@@ -408,6 +408,8 @@ export default class MonitorDetailsV1 extends Component {
     //   tabs.push({ ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() });
     // }
 
+    if (tabs.length < 2) return null; // Wazuh: hide tabs when there are less than 2
+
     return tabs.map((tab, index) => (
       <EuiTab
         key={`${tab.id}${index}`}
@@ -584,7 +586,7 @@ export default class MonitorDetailsV1 extends Component {
         {displayTableTabs ? (
           <div>
             {monitor.monitor_type !== MONITOR_TYPE.COMPOSITE_LEVEL ? (
-              <EuiTabs size="s">{this.renderTableTabs()}</EuiTabs>
+               <EuiTabs size="s">{this.renderTableTabs()}</EuiTabs>
             ) : null}
             {this.state.tabContent}
           </div>

--- a/public/pages/MonitorDetails/containers/MonitorDetailsV2.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetailsV2.js
@@ -595,6 +595,8 @@ export default class MonitorDetailsV2 extends Component {
     //   tabs.push({ ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() });
     // }
 
+    if (tabs.length < 2) return null; // Wazuh: hide tabs when there are less than 2
+
     return tabs.map((tab, index) => (
       <EuiTab
         key={`${tab.id}${index}`}

--- a/public/pages/MonitorDetails/containers/MonitorDetailsV2.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetailsV2.js
@@ -590,9 +590,10 @@ export default class MonitorDetailsV2 extends Component {
     const { tabId, monitor } = this.state;
     const tabs = [{ ...TABLE_TAB_IDS.ALERTS, content: this.renderAlertsTable() }];
 
-    if (monitor.monitor_type !== MONITOR_TYPE.COMPOSITE_LEVEL) {
-      tabs.push({ ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() });
-    }
+    // Wazuh: deprecated `Document findings` tab
+    // if (monitor.monitor_type !== MONITOR_TYPE.COMPOSITE_LEVEL) {
+    //   tabs.push({ ...TABLE_TAB_IDS.FINDINGS, content: this.renderFindingsTable() });
+    // }
 
     return tabs.map((tab, index) => (
       <EuiTab


### PR DESCRIPTION
### Description
- Hides `Document findings` tab in Active Response and Per document monitor details.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-alerting/issues/86

### Evidence  

<img width="2934" height="1508" alt="image" src="https://github.com/user-attachments/assets/540b0d42-372c-43cc-b20e-2b0a17d8a730" />

<img width="2932" height="1502" alt="image" src="https://github.com/user-attachments/assets/5d479faa-bebd-488c-ba6e-374111183279" />

### Test
- Go to the details of a Per Document and Active Response monitor and verify no `Document findings` tab is visible.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
