### PR TITLE
Fix tag references on bump when --tag is provided

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -510,7 +510,6 @@ main() {
   update_package_json
   update_changelog
   update_branch_reference_defaults
-  update_manual_build_workflow
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -8,7 +8,6 @@ REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
 DATE_TIME=$(date "+%Y-%m-%d_%H-%M-%S-%3N")
 LOG_FILE="${SCRIPT_PATH}/repository_bumper_${DATE_TIME}.log"
 PACKAGE_JSON="${REPO_PATH}/package.json"
-WAZUH_DASHBOARD_ALERTING_WORKFLOW_FILE="${REPO_PATH}/.github/workflows/5_builderpackage_alerting_plugin.yml"
 VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
@@ -437,27 +436,6 @@ update_package_json() {
   fi
 }
 
-update_manual_build_workflow() {
-  local WORKFLOW_FILE="$WAZUH_DASHBOARD_ALERTING_WORKFLOW_FILE"
-  if [ -f "$WORKFLOW_FILE" ]; then
-    log "Processing $WORKFLOW_FILE"
-    local modified=false
-    # Update the default value for the reference input
-    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
-      log "Attempting to update default reference to $VERSION in $WORKFLOW_FILE"
-      sed_inplace "s/^\([[:space:]]*default:[[:space:]]*\)$CURRENT_VERSION/\1$VERSION/" "$WORKFLOW_FILE"
-      modified=true
-    fi
-
-    if [[ $modified == true ]]; then
-      log "Successfully updated $WORKFLOW_FILE with new default reference: $VERSION"
-    fi
-  else
-    log "WARNING: $WORKFLOW_FILE not found. Skipping update."
-  fi
-  log "Updating $WAZUH_DASHBOARD_ALERTING_WORKFLOW_FILE workflow..."
-}
-
 # Replace "main" in default: reference inputs (5_* workflows only) when not in --set_as_main mode.
 update_branch_reference_defaults() {
   if [[ "$skip_urls" == "yes" ]]; then
@@ -465,7 +443,7 @@ update_branch_reference_defaults() {
     return 0
   fi
 
-  local bump_string="$VERSION"
+  local bump_string="$GIT_REF_REPLACEMENT"
   local files=(
     "${REPO_PATH}/.github/workflows/5_builderpackage_alerting_plugin.yml"
     "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
@@ -479,6 +457,20 @@ update_branch_reference_defaults() {
     log "Replacing default: main with default: ${bump_string} in $f (where applicable)"
     sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
   done
+}
+
+get_git_ref_replacement(){
+  local replacement
+  if [ "$TAG" = true ]; then
+    replacement="v${VERSION}"
+    if [ -n "$STAGE" ]; then
+      replacement+="-${STAGE}"
+    fi
+  else
+    replacement="${VERSION}"
+  fi
+
+  GIT_REF_REPLACEMENT="$replacement"
 }
 
 # --- Main Execution ---
@@ -509,6 +501,8 @@ main() {
   # Compare versions and determine revision
   compare_versions_and_set_revision
 
+  get_git_ref_replacement
+  
   # Start file modifications
   log "Starting file modifications..."
 


### PR DESCRIPTION
### Description

This pull request fixes the git references in some files on bump when --tag is provided. 

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/1295


### Evidences

```diff
git --no-pager diff
diff --git a/.github/workflows/5_builderpackage_alerting_plugin.yml b/.github/workflows/5_builderpackage_alerting_plugin.yml
index 00d3b27..e56811b 100644
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0-beta3
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 555962d..3bbf201 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -6,7 +6,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
diff --git a/CHANGELOG.md b/CHANGELOG.md
index e8b24fa..6f9b82f 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh dashboard alerting plugin will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 02
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index 0533024..a57868a 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta2"
+  "stage": "beta3"
 }
diff --git a/package.json b/package.json
index 10a2b7a..9b39eec 100644
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "02"
+    "revision": "03"
   },
   "homepage": "https://github.com/opensearch-project/alerting-dashboards-plugin",
   "repository": {
```


### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## Other

| Test | Result |
| --- |  --- |
| Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff` | :black_circle: |

**Details**
<details>
<summary>:black_circle: Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff`</summary>

</details>
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 
