### PR TITLE
Fix wrong editions on bumper for tag flag

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -373,9 +373,15 @@ compare_versions_and_set_revision() {
         # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
         local current_revision_int=$((10#$current_revision_val))
         local new_revision_int=$((current_revision_int + 1))
-        # Format back to two digits with leading zero
-        REVISION=$(printf "%02d" "$new_revision_int")
-        log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        if [ -n "$STAGE" ] && [ "$STAGE" != "$CURRENT_STAGE" ]; then
+          # Format back to two digits with leading zero
+          log "Incrementing revision."
+          REVISION=$(printf "%02d" "$new_revision_int")
+          log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        else
+          REVISION=$(printf "%02d" "$current_revision_int")
+          log "Current revision: $current_revision_val."
+        fi
       fi
     fi
   fi
@@ -395,7 +401,7 @@ update_root_version_json() {
     fi
 
     # Update stage in VERSION.json
-    if [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
+    if [ -n "$STAGE" ] && [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
       sed_inplace "s/^[[:space:]]*\"stage\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
       modified=true
     fi


### PR DESCRIPTION
### Description
This pull request fixes wrong editions on bumper for --tag flag.
 
### Issues Resolved
#98 

### Evidence

The current version is: `5.0.0`
The current stage is: `beta3`

<details><summary> <code>bash tools/repository_bumper.sh --tag</code> </summary>

**Output:**

```shell
[2026-06-10 11:46:02] Starting repository bump process
[2026-06-10 11:46:02] Repository path: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting
[2026-06-10 11:46:02] Version: 
[2026-06-10 11:46:02] Stage: 
[2026-06-10 11:46:02] Attempting to extract current version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:46:02] Successfully extracted version using sed: 5.0.0
[2026-06-10 11:46:02] Current version detected in VERSION.json: 5.0.0
[2026-06-10 11:46:02] Attempting to extract current stage from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:46:02] Successfully extracted stage using sed: beta3
[2026-06-10 11:46:02] Current stage detected in VERSION.json: beta3
[2026-06-10 11:46:02] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed...
[2026-06-10 11:46:02] Successfully extracted revision using sed: 03
[2026-06-10 11:46:02] Current revision detected in package.json: 03
[2026-06-10 11:46:02] Default revision set to: 00
[2026-06-10 11:46:02] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 11:46:02] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 11:46:02] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:46:02] Successfully extracted revision using sed: 03
[2026-06-10 11:46:02] Current revision: 03.
[2026-06-10 11:46:02] Final revision determined: 03
[2026-06-10 11:46:02] Starting file modifications...
[2026-06-10 11:46:02] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json
[2026-06-10 11:46:02] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 11:46:02] Updating CHANGELOG.md...
[2026-06-10 11:46:02] Attempting to extract .version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:46:02] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 11:46:02] Replacing default: main with default: v5.0.0 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml (where applicable)
[2026-06-10 11:46:02] Replacing default: main with default: v5.0.0 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 11:46:02] File modifications completed.
[2026-06-10 11:46:02] Repository bump completed successfully. Log file: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/tools/repository_bumper_2026-06-10_11-46-02-448.log
```


**Diff:**

```diff
diff --git a/.github/workflows/5_builderpackage_alerting_plugin.yml b/.github/workflows/5_builderpackage_alerting_plugin.yml
index 00d3b27..51bb30c 100644
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 555962d..32804f5 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -6,7 +6,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
```

</details>


<details><summary> <code>bash tools/repository_bumper.sh --stage beta3 --tag</code> </summary>

**Output:**

```shell
[2026-06-10 11:48:56] Starting repository bump process
[2026-06-10 11:48:56] Repository path: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting
[2026-06-10 11:48:56] Version: 
[2026-06-10 11:48:56] Stage: beta3
[2026-06-10 11:48:56] Attempting to extract current version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:48:56] Successfully extracted version using sed: 5.0.0
[2026-06-10 11:48:56] Current version detected in VERSION.json: 5.0.0
[2026-06-10 11:48:56] Attempting to extract current stage from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:48:56] Successfully extracted stage using sed: beta3
[2026-06-10 11:48:56] Current stage detected in VERSION.json: beta3
[2026-06-10 11:48:56] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed...
[2026-06-10 11:48:56] Successfully extracted revision using sed: 03
[2026-06-10 11:48:56] Current revision detected in package.json: 03
[2026-06-10 11:48:56] Default revision set to: 00
[2026-06-10 11:48:56] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 11:48:56] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 11:48:56] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:48:56] Successfully extracted revision using sed: 03
[2026-06-10 11:48:56] Current revision: 03.
[2026-06-10 11:48:56] Final revision determined: 03
[2026-06-10 11:48:56] Starting file modifications...
[2026-06-10 11:48:56] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json
[2026-06-10 11:48:56] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 11:48:56] Updating CHANGELOG.md...
[2026-06-10 11:48:56] Attempting to extract .version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:48:56] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 11:48:56] Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only.
[2026-06-10 11:48:56] CHANGELOG.md revision updated successfully.
[2026-06-10 11:48:56] Replacing default: main with default: v5.0.0-beta3 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml (where applicable)
[2026-06-10 11:48:56] Replacing default: main with default: v5.0.0-beta3 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 11:48:56] File modifications completed.
[2026-06-10 11:48:56] Repository bump completed successfully. Log file: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/tools/repository_bumper_2026-06-10_11-48-56-627.log
```


**Diff:**

```diff
diff --git a/.github/workflows/5_builderpackage_alerting_plugin.yml b/.github/workflows/5_builderpackage_alerting_plugin.yml
index 00d3b27..e56811b 100644
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0-beta3
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 555962d..3bbf201 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -6,7 +6,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
```

</details>


<details><summary> <code>bash tools/repository_bumper.sh --stage beta4 --tag</code> </summary>

**Output:**

```shell
[2026-06-10 11:58:03] Starting repository bump process
[2026-06-10 11:58:03] Repository path: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting
[2026-06-10 11:58:03] Version: 
[2026-06-10 11:58:03] Stage: beta4
[2026-06-10 11:58:03] Attempting to extract current version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:58:03] Successfully extracted version using sed: 5.0.0
[2026-06-10 11:58:03] Current version detected in VERSION.json: 5.0.0
[2026-06-10 11:58:03] Attempting to extract current stage from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:58:03] Successfully extracted stage using sed: beta3
[2026-06-10 11:58:03] Current stage detected in VERSION.json: beta3
[2026-06-10 11:58:03] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed...
[2026-06-10 11:58:03] Successfully extracted revision using sed: 03
[2026-06-10 11:58:03] Current revision detected in package.json: 03
[2026-06-10 11:58:03] Default revision set to: 00
[2026-06-10 11:58:03] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 11:58:03] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 11:58:03] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:58:03] Successfully extracted revision using sed: 03
[2026-06-10 11:58:03] Incrementing revision.
[2026-06-10 11:58:03] Current revision: 03. New revision set to: 04
[2026-06-10 11:58:03] Final revision determined: 04
[2026-06-10 11:58:03] Starting file modifications...
[2026-06-10 11:58:03] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json
[2026-06-10 11:58:03] Successfully updated /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json with new version: 5.0.0 and stage: beta4
[2026-06-10 11:58:03] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 11:58:03] Attempting to update revision to 04 within 'wazuh' object in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 11:58:03] Successfully updated /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json with new version: 5.0.0 and revision: 04
[2026-06-10 11:58:03] Updating CHANGELOG.md...
[2026-06-10 11:58:03] Attempting to extract .version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:58:03] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 11:58:03] Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only.
[2026-06-10 11:58:03] CHANGELOG.md revision updated successfully.
[2026-06-10 11:58:03] Replacing default: main with default: v5.0.0-beta4 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml (where applicable)
[2026-06-10 11:58:03] Replacing default: main with default: v5.0.0-beta4 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 11:58:03] File modifications completed.
[2026-06-10 11:58:03] Repository bump completed successfully. Log file: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/tools/repository_bumper_2026-06-10_11-58-03-544.log
```


**Diff:**

```diff
diff --git a/.github/workflows/5_builderpackage_alerting_plugin.yml b/.github/workflows/5_builderpackage_alerting_plugin.yml
index 00d3b27..7db8a5f 100644
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0-beta4
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta4
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 555962d..5c4aa70 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -6,7 +6,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta4
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 6f9b82f..91c0182 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh dashboard alerting plugin will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 04
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index a57868a..cec3019 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta3"
+  "stage": "beta4"
 }
diff --git a/package.json b/package.json
index 9b39eec..49538cd 100644
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "03"
+    "revision": "04"
   },
   "homepage": "https://github.com/opensearch-project/alerting-dashboards-plugin",
   "repository": {
```

</details>


<details><summary> <code>bash tools/repository_bumper.sh --version 5.0.0 --stage beta4</code> </summary>

**Output:**

```shell
[2026-06-10 11:59:45] Starting repository bump process
[2026-06-10 11:59:45] Repository path: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting
[2026-06-10 11:59:45] Version: 5.0.0
[2026-06-10 11:59:45] Stage: beta4
[2026-06-10 11:59:45] Attempting to extract current version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:59:45] Successfully extracted version using sed: 5.0.0
[2026-06-10 11:59:45] Current version detected in VERSION.json: 5.0.0
[2026-06-10 11:59:45] Attempting to extract current stage from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 11:59:45] Successfully extracted stage using sed: beta3
[2026-06-10 11:59:45] Current stage detected in VERSION.json: beta3
[2026-06-10 11:59:45] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed...
[2026-06-10 11:59:45] Successfully extracted revision using sed: 03
[2026-06-10 11:59:45] Current revision detected in package.json: 03
[2026-06-10 11:59:45] Default revision set to: 00
[2026-06-10 11:59:45] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 11:59:45] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 11:59:45] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:59:45] Successfully extracted revision using sed: 03
[2026-06-10 11:59:45] Incrementing revision.
[2026-06-10 11:59:45] Current revision: 03. New revision set to: 04
[2026-06-10 11:59:45] Final revision determined: 04
[2026-06-10 11:59:45] Starting file modifications...
[2026-06-10 11:59:45] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json
[2026-06-10 11:59:45] Successfully updated /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json with new version: 5.0.0 and stage: beta4
[2026-06-10 11:59:45] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 11:59:45] Attempting to update revision to 04 within 'wazuh' object in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 11:59:45] Successfully updated /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json with new version: 5.0.0 and revision: 04
[2026-06-10 11:59:45] Updating CHANGELOG.md...
[2026-06-10 11:59:45] Attempting to extract .version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 11:59:45] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 11:59:45] Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only.
[2026-06-10 11:59:45] CHANGELOG.md revision updated successfully.
[2026-06-10 11:59:45] Replacing default: main with default: 5.0.0 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml (where applicable)
[2026-06-10 11:59:45] Replacing default: main with default: 5.0.0 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 11:59:45] File modifications completed.
[2026-06-10 11:59:45] Repository bump completed successfully. Log file: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/tools/repository_bumper_2026-06-10_11-59-45-120.log
```


**Diff:**

```diff
diff --git a/.github/workflows/5_builderpackage_alerting_plugin.yml b/.github/workflows/5_builderpackage_alerting_plugin.yml
index 00d3b27..c5005cf 100644
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: 5.0.0
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: 5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 555962d..55c5670 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -6,7 +6,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: 5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 6f9b82f..91c0182 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh dashboard alerting plugin will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 04
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index a57868a..cec3019 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta3"
+  "stage": "beta4"
 }
diff --git a/package.json b/package.json
index 9b39eec..49538cd 100644
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "03"
+    "revision": "04"
   },
   "homepage": "https://github.com/opensearch-project/alerting-dashboards-plugin",
   "repository": {
```

</details>


<details><summary> <code>bash tools/repository_bumper.sh --version 5.0.0 --stage beta4 --tag</code> </summary>

**Output:**

```shell
[2026-06-10 12:00:52] Starting repository bump process
[2026-06-10 12:00:52] Repository path: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting
[2026-06-10 12:00:52] Version: 5.0.0
[2026-06-10 12:00:52] Stage: beta4
[2026-06-10 12:00:52] Attempting to extract current version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 12:00:52] Successfully extracted version using sed: 5.0.0
[2026-06-10 12:00:52] Current version detected in VERSION.json: 5.0.0
[2026-06-10 12:00:52] Attempting to extract current stage from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json using sed...
[2026-06-10 12:00:52] Successfully extracted stage using sed: beta3
[2026-06-10 12:00:52] Current stage detected in VERSION.json: beta3
[2026-06-10 12:00:52] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed...
[2026-06-10 12:00:52] Successfully extracted revision using sed: 03
[2026-06-10 12:00:52] Current revision detected in package.json: 03
[2026-06-10 12:00:52] Default revision set to: 00
[2026-06-10 12:00:52] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 12:00:52] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 12:00:52] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 12:00:52] Successfully extracted revision using sed: 03
[2026-06-10 12:00:52] Incrementing revision.
[2026-06-10 12:00:52] Current revision: 03. New revision set to: 04
[2026-06-10 12:00:52] Final revision determined: 04
[2026-06-10 12:00:52] Starting file modifications...
[2026-06-10 12:00:52] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json
[2026-06-10 12:00:52] Successfully updated /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/VERSION.json with new version: 5.0.0 and stage: beta4
[2026-06-10 12:00:52] Processing /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 12:00:52] Attempting to update revision to 04 within 'wazuh' object in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json
[2026-06-10 12:00:52] Successfully updated /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json with new version: 5.0.0 and revision: 04
[2026-06-10 12:00:52] Updating CHANGELOG.md...
[2026-06-10 12:00:52] Attempting to extract .version from /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/package.json using sed (Note: This is fragile)
[2026-06-10 12:00:52] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 12:00:52] Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only.
[2026-06-10 12:00:52] CHANGELOG.md revision updated successfully.
[2026-06-10 12:00:52] Replacing default: main with default: v5.0.0-beta4 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderpackage_alerting_plugin.yml (where applicable)
[2026-06-10 12:00:52] Replacing default: main with default: v5.0.0-beta4 in /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 12:00:52] File modifications completed.
[2026-06-10 12:00:52] Repository bump completed successfully. Log file: /home/adman23/development/wazuh/src/wazuh-dashboard-alerting/tools/repository_bumper_2026-06-10_12-00-52-648.log
```


**Diff:**

```diff
diff --git a/.github/workflows/5_builderpackage_alerting_plugin.yml b/.github/workflows/5_builderpackage_alerting_plugin.yml
index 00d3b27..7db8a5f 100644
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0-beta4
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta4
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 555962d..5c4aa70 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -6,7 +6,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta4
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 6f9b82f..91c0182 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh dashboard alerting plugin will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 04
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index a57868a..cec3019 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta3"
+  "stage": "beta4"
 }
diff --git a/package.json b/package.json
index 9b39eec..49538cd 100644
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "03"
+    "revision": "04"
   },
   "homepage": "https://github.com/opensearch-project/alerting-dashboards-plugin",
   "repository": {
```

</details>


### Tests

- Test each command in evidence and verify output and git diff are correct.
- Test any other use case that could be of interest.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 
