### PR TITLE
Add bump-issue-link parameter to bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -18,6 +18,10 @@ on:
         description: "Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>"
         required: true
         type: string
+      bump-issue-link:
+        description: 'Issue link used in the original bump (required for revert if different from issue-link)'
+        required: false
+        type: string
       id:
         description: "Optional identifier for the run"
         required: false
@@ -144,9 +148,18 @@ jobs:
         id: revert_step
         if: inputs.revert == true
         run: |
+          # 1. Get the current issue number (for the new revert branch/PR)
           ISSUE_NUMBER=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
 
-          BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
+          # 2. Get the issue number from the original bump (if provided; otherwise, defaults to the current one)
+          if [ -n "${{ inputs.bump-issue-link }}" ]; then
+            BUMP_ISSUE_NUMBER=$(echo "${{ inputs.bump-issue-link }}" | awk -F'/' '{print $NF}')
+          else
+            BUMP_ISSUE_NUMBER=$ISSUE_NUMBER
+          fi
+
+          # 3. Search for the original bump branch using the obtained BUMP ISSUE number
+          BUMP_BRANCH="enhancement/wqa${BUMP_ISSUE_NUMBER}-bump-${{ github.ref_name }}"
 
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
@@ -161,6 +174,8 @@ jobs:
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
 
           git revert -m 1 $MERGE_COMMIT --no-commit
+
+          # Remove the files to prevent them from being included in the revert commit
 
           git checkout HEAD -- VERSION.json 2>/dev/null || true
           git checkout HEAD -- CHANGELOG.md 2>/dev/null || true


### PR DESCRIPTION
### Description
This pull request adds the `bump-issue-link` parameter to the bumper workflow that allows revert the changes from a different bump PR.

### Issues Resolved
[#101](https://github.com/wazuh/wazuh-dashboard-alerting/issues/101)

### Evidences

- Bump: https://github.com/FernandoCastilla/wazuh-dashboard-alerting/actions/runs/27610351469
<img width="1856" height="959" alt="Captura desde 2026-06-16 12-21-52" src="https://github.com/user-attachments/assets/380d8783-cd60-4790-b3d5-c06d3f6111d0" />
<img width="1856" height="959" alt="Captura desde 2026-06-16 12-22-25" src="https://github.com/user-attachments/assets/875ee800-27dc-441c-98cc-8cc06a1986e0" />

- Revert: https://github.com/FernandoCastilla/wazuh-dashboard-alerting/actions/runs/27610949114
<img width="1856" height="959" alt="Captura desde 2026-06-16 12-24-02" src="https://github.com/user-attachments/assets/c71d69b4-4f2d-4b74-86c4-3704c913a51d" />
<img width="1856" height="959" alt="Captura desde 2026-06-16 12-24-11" src="https://github.com/user-attachments/assets/c2aa8c1c-1bbf-4d91-a7b0-01208d1182c0" />

### Check List
- [x] Commits are signed per the DCO using --signoff
