### PR TITLE
Migrate artifact handling to S3 in build workflows

### DIFF
--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -41,4 +41,5 @@ jobs:
       command: 'yarn build'
       artifact_name: 'alerting-dashboards'
       artifact_path: './wazuh-dashboard-alerting/build'
+      workflow_run: 5_builderpackage_alerting_plugin
     secrets: inherit

--- a/.github/workflows/5_builderpackage_alerting_plugin.yml
+++ b/.github/workflows/5_builderpackage_alerting_plugin.yml
@@ -36,10 +36,12 @@ jobs:
   build:
     name: Build app package
     uses: ./.github/workflows/5_builderprecompiled_base-dev-environment.yml
+    permissions:
+      id-token: write
     with:
       reference: ${{ inputs.reference }}
       command: 'yarn build'
       artifact_name: 'alerting-dashboards'
       artifact_path: './wazuh-dashboard-alerting/build'
-      workflow_run: 5_builderpackage_alerting_plugin
+      execution_repository: wazuh-dashboard-alerting/5_builderpackage_alerting_plugin
     secrets: inherit

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -32,6 +32,15 @@ on:
         type: boolean
         default: false
         required: false
+      workflow_run:
+        type: string
+        default: ''
+        description: Workflow run to upload the artifact to.
+        required: false
+
+env:
+  CI_DEV_INTERNAL_BUCKET: s3://xdrsiem-ci-dev-internal
+  CI_ARTIFACTS_REPO: wazuh-dashboard-alerting
 
 jobs:
   # Deploy the plugin in a development environment and run a command
@@ -40,7 +49,7 @@ jobs:
     name: Deploy and run command
     runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - name: Step 01 - Download the plugin's source code
+      - name: Download the plugin's source code
         uses: actions/checkout@v4
         with:
           repository: wazuh/wazuh-dashboard-alerting
@@ -49,10 +58,10 @@ jobs:
 
       # Fix source code ownership so the internal user of the Docker
       # container is also owner.
-      - name: Step 02 - Change code ownership
+      - name: Change code ownership
         run: sudo chown 1000:1000 -R wazuh-dashboard-alerting;
 
-      - name: Step 03 - Set up the environment and run the command
+      - name: Set up the environment and run the command
         run: |
           # Read the platform version from the package.json file
           echo "Reading the platform version from the package.json...";
@@ -83,13 +92,21 @@ jobs:
           echo "version=$(jq -r '.wazuh.version' $(pwd)/wazuh-dashboard-alerting/package.json)" >> $GITHUB_ENV
           echo "revision=$(jq -r '.wazuh.revision' $(pwd)/wazuh-dashboard-alerting/package.json)" >> $GITHUB_ENV
 
-      - name: Step 04 - Upload artifact to GitHub
+      - name: Configure AWS credentials
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
-        uses: actions/upload-artifact@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          name: ${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
-          path: ${{ inputs.artifact_path }}
-          overwrite: true
+          role-to-assume: ${{ secrets.AWS_QA_AUTOMATION_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload artifact to S3
+        if: ${{ inputs.artifact_name && inputs.artifact_path }}
+        run: |
+          artifact_zip="${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip"
+          s3_path="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ inputs.workflow_run }}/${{ github.run_id }}/${artifact_zip}"
+          packagePath=$(find "${GITHUB_WORKSPACE}/${{ inputs.artifact_path }}" -type f)
+          aws s3 cp "${packagePath}" "${s3_path}"
+          echo "::notice::Artifact uploaded to ${s3_path}"
 
       - name: Step 05 - Upload coverage results to GitHub
         if: ${{ inputs.notify_jest_coverage_summary && github.event_name == 'pull_request' }}

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -32,15 +32,14 @@ on:
         type: boolean
         default: false
         required: false
-      workflow_run:
+      execution_repository:
         type: string
         default: ''
-        description: Workflow run to upload the artifact to.
+        description: 'Repository and workflow run to upload the artifact to (format: repo/workflow).'
         required: false
 
 env:
-  CI_DEV_INTERNAL_BUCKET: s3://xdrsiem-ci-dev-internal
-  CI_ARTIFACTS_REPO: wazuh-dashboard-alerting
+  CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
 
 jobs:
   # Deploy the plugin in a development environment and run a command
@@ -48,6 +47,8 @@ jobs:
   deploy_and_run_command:
     name: Deploy and run command
     runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      id-token: write
     steps:
       - name: Download the plugin's source code
         uses: actions/checkout@v4
@@ -96,14 +97,14 @@ jobs:
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_QA_AUTOMATION_ROLE }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload artifact to S3
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
         run: |
           artifact_zip="${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip"
-          s3_path="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ env.CI_ARTIFACTS_REPO }}/${{ inputs.workflow_run }}/${{ github.run_id }}/${artifact_zip}"
+          s3_path="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ inputs.execution_repository }}/${{ github.run_id }}/${artifact_zip}"
           packagePath=$(find "${GITHUB_WORKSPACE}/${{ inputs.artifact_path }}" -type f)
           aws s3 cp "${packagePath}" "${s3_path}"
           echo "::notice::Artifact uploaded to ${s3_path}"


### PR DESCRIPTION
### Description

Migrate artifact handling to S3 in build workflows

### Evidence

- https://github.com/wazuh/wazuh-dashboard-alerting/actions/runs/28457564767

### Issues Resolved

- **IDR 5301**

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [X] Commits are signed per the DCO using --signoff
