### PR TITLE
Optimize Draft PRs

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -3,13 +3,10 @@ on:
   pull_request:
     branches: ['*']
     types: [opened, synchronize, reopened, ready_for_review]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '3.6'
-  OPENSEARCH_VERSION: '3.6.0-SNAPSHOT'
-  ALERTING_PLUGIN_BRANCH: '3.6'
+  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
+  ALERTING_PLUGIN_BRANCH: 'main'
 jobs:
   tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches: ['*']
     types: [opened, synchronize, reopened, ready_for_review]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
   OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,9 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
-  ALERTING_PLUGIN_BRANCH: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '3.6'
+  OPENSEARCH_VERSION: '3.6.0-SNAPSHOT'
+  ALERTING_PLUGIN_BRANCH: '3.6'
 jobs:
   tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -6,10 +6,14 @@ on:
   pull_request:
     branches: ['*']
     types: [opened, synchronize, reopened, ready_for_review]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
 jobs:
   Get-CI-Image-Tag:
+    if: github.event.pull_request.draft == false
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch-dashboards

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ['*']
     types: [opened, synchronize, reopened, ready_for_review]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   OPENSEARCH_VERSION: '3.6.0'
   CI: 1

--- a/public/pages/Home/__snapshots__/Home.test.js.snap
+++ b/public/pages/Home/__snapshots__/Home.test.js.snap
@@ -31,18 +31,6 @@ exports[`Home renders 1`] = `
         Monitors
       </span>
     </button>
-    <button
-      aria-selected="false"
-      class="euiTab"
-      role="tab"
-      type="button"
-    >
-      <span
-        class="euiTab__content"
-      >
-        Destinations
-      </span>
-    </button>
   </div>
   <div
     style="padding:16px"


### PR DESCRIPTION
### Description

Conditionals are added so that the checks are not run when the pull request is in draft status.

A concurrency check is added to cancel previous executions if a commit is made without the PR being in draft status.
 
The Cypress workflow was disabled because it is failing. 
 
### Test

<img width="388" height="323" alt="image" src="https://github.com/user-attachments/assets/1652a7aa-8b44-4156-b377-05ca51297bf1" />

<img width="284" height="370" alt="image" src="https://github.com/user-attachments/assets/5461b553-aeda-4966-a3cd-a4b582bc7f45" />

