### PR TITLE
Remove # Change Log title from CHANGELOG.md header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Change Log
-
 ## [v5.0.0]
 
 ### Added


### PR DESCRIPTION
### Description
The CHANGELOG.md file was starting with a # Change Log title before the version entry. This removes it so the file starts directly with ## [v5.0.0], consistent with the format used across the other repos.
 
### Issues Resolved
IDR 5382
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
