### PR TITLE
Create issue-creation skill and update PR template

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -25,7 +25,7 @@ you to create/open/submit it.
 - **English everywhere.** Describe the _why_, not just the _what_.
 - **Issues arrive as URLs** and may live in a different repo. Read them with
   `gh issue view <url>` and classify the source (see below) — it changes both
-  "Issues Resolved" and the CHANGELOG.
+  the PR's `## Description` closing reference and the CHANGELOG.
 
 ## Issue source: public vs internal
 
@@ -33,11 +33,12 @@ Detect the source repo from the issue URL:
 
 - **Internal** — the URL/repo contains `internal-devel-request` (e.g.
   `https://github.com/wazuh/internal-devel-requests/issues/5526`):
-  - PR "Issues Resolved": **leave empty** — never expose the internal link.
+  - PR `## Description`: **no closing reference** — never expose the internal
+    link.
   - CHANGELOG: **no entry** for internal-devel-requests issues.
 - **Public** — any other repo (e.g.
   `https://github.com/wazuh/wazuh-dashboard-alerting/issues/123`):
-  - PR "Issues Resolved": `closes #<n>` (same repo) or `closes <issue-url>`
+  - PR `## Description`: `Closes #<n>` (same repo) or `Closes <issue-url>`
     (another public repo).
   - CHANGELOG: add an entry linking to the **issue** (see step 4).
 
@@ -113,37 +114,16 @@ When unsure (and the issue is public), add an entry.
 
 ### 5. Fill the PR body
 
-Fill the repository PR template **verbatim** (keep every heading and checklist
-item exactly).
+Read [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md)
+first and fill it **verbatim** — keep every heading and checklist item exactly;
+do not restate its structure here, just follow the file. It has a dedicated
+`### Results and Evidence` section — put the screenshot/video (REQUIRED for any
+UI change) there.
 
-> **repo-specific (wazuh-dashboard-alerting):** this mirrors
-> [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md).
-> Read it first and keep this block in sync if the repo template changes. The
-> template has **no dedicated Evidence section** — put the screenshot/video
-> (REQUIRED for any UI change) and test notes under `### Description`.
-
-```markdown
-### Description
-[Describe what this change achieves]
-
-### Issues Resolved
-[List any issues this PR will resolve]
-
-### Check List
-- [ ] New functionality includes testing.
-  - [ ] All tests pass
-- [ ] New functionality has been documented.
-  - [ ] New functionality has javadoc added
-- [ ] Commits are signed per the DCO using --signoff
-
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
-```
-
-Fill each section with real content; check the boxes that genuinely apply. For
-**Issues Resolved**: public issue → closing keyword (`closes`, `fixes`, `fix`)
-with `#<n>` or the full issue URL; **internal-devel-requests issue → leave the
-section empty** (see "Issue source" above).
+Fill each section with real content; check the boxes that genuinely apply. In
+`## Description`: public issue → `Closes #<n>` or the full issue URL;
+**internal-devel-requests issue → no closing reference** (see "Issue source"
+above).
 
 **Default deliverable — pre-flight report.** Unless the user asked you to create the
 PR, stop here and output the filled body plus this report for the human to act on:
@@ -166,12 +146,11 @@ PR pre-flight
 gh pr create --draft \
   --base <version-branch> \
   --title "<Imperative, capitalized subject>" \
-  --body "$(cat <<'EOF'
-### Description
-...
-EOF
-)"
+  --body-file .github/PULL_REQUEST_TEMPLATE.md
 ```
+
+Fill the body file's sections before running this (or use `--body-file` with an
+already-filled temp file); don't submit the template placeholders as-is.
 
 ### 7. Mark Ready for review — only when explicitly asked
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -142,15 +142,16 @@ PR pre-flight
 
 ### 6. Create as Draft — only when explicitly asked
 
+Write the body filled in step 5 (not the blank template) to a temp file, then
+pass that file — never point `--body-file` at the template path itself, or the
+PR is created with the empty placeholder text.
+
 ```bash
 gh pr create --draft \
   --base <version-branch> \
   --title "<Imperative, capitalized subject>" \
-  --body-file .github/PULL_REQUEST_TEMPLATE.md
+  --body-file /tmp/pr-body.md
 ```
-
-Fill the body file's sections before running this (or use `--body-file` with an
-already-filled temp file); don't submit the template placeholders as-is.
 
 ### 7. Mark Ready for review — only when explicitly asked
 

--- a/.claude/skills/develop-issue/SKILL.md
+++ b/.claude/skills/develop-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: develop-issue
-description: Implement a GitHub issue end-to-end in a Wazuh Dashboard repo — plan, code following repo conventions, add colocated tests, validate with check-standards, add the CHANGELOG entry, and deliver a filled PR-template body (leaving Evidence/screenshot to the developer) WITHOUT opening the PR. Use when the user provides an issue to develop, implement, or work on.
+description: Implement a GitHub issue end-to-end in a Wazuh Dashboard repo — plan, code following repo conventions, add colocated tests, validate with check-standards, add the CHANGELOG entry, and deliver a filled PR-template body (leaving Results and Evidence/screenshot to the developer) WITHOUT opening the PR. Use when the user provides an issue to develop, implement, or work on.
 ---
 
 # Develop an issue (issue → code → tests → delivery)
@@ -33,7 +33,8 @@ gh issue view <issue-url>
 
 - **Internal** — URL contains `internal-devel-request` (e.g.
   `wazuh/internal-devel-requests`): the issue link is **not** exposed in the PR
-  ("Issues Resolved" stays empty) and there is **no CHANGELOG entry**.
+  (`## Description` gets no closing reference) and there is **no CHANGELOG
+  entry**.
 - **Public** — any other repo (e.g. `wazuh/wazuh-dashboard-alerting`): link it in
   the PR and add a CHANGELOG entry pointing to the issue.
 
@@ -87,11 +88,11 @@ for **internal-devel-requests** issues, and for tooling/docs/test-only changes
 
 Invoke **create-pr** in its default prepare-and-hand-off mode. Output:
 
-- The filled PR-template body, with the **`### Description`** completed, the
-  **`### Check List`** boxes that genuinely apply checked, and
-  **`### Issues Resolved` left empty** for internal-devel-requests issues (or
-  `closes #<n>` / issue URL for public ones), plus a screenshot/video reminder for
-  any UI change.
+- The filled PR-template body, with the **`## Description`** completed (public
+  issue → `Closes #<n>` / issue URL; internal-devel-requests → no closing
+  reference), the **`### Review Checklist`** boxes that genuinely apply checked,
+  and a screenshot/video reminder under **`### Results and Evidence`** for any
+  UI change.
 - The pre-flight report (branch, suggested base, DCO status, check-standards
   result, CHANGELOG status, and the `gh pr create` command to run when ready).
 

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -3,7 +3,7 @@ name: issue-creation
 description: Create a well-formed GitHub issue in a Wazuh Dashboard repo — pick the right issue template, run an issue-first duplicate check, and produce a ready-to-file body with the template's default labels. Use when the user asks to create, open, file, or draft an issue.
 ---
 
-# Create a wazuh-dashboard-alerting issue
+# Create a Wazuh Dashboard issue
 
 Pick the right issue template, check for duplicates first, then fill the
 template verbatim and hand off a ready-to-file body.

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -31,6 +31,7 @@ ambiguous between two rows.
 | New feature / enhancement request | `feature_request.md` | `enhancement, untriaged` |
 | New OpenSearch version compatibility tracking | `compatibility_request.md` | `request/operational, level/task, type/maintenance` |
 | Documentation gap or fix | `documentation.md` | *(none — see note below)* |
+| Engineering task / improvement | `task_template.md` | `level/task` |
 
 ### 2. Issue-first duplicate check
 
@@ -91,9 +92,7 @@ fill it verbatim; do not inline template bodies in this skill.
 ### 4. Labels
 
 Keep the template's default labels as-is; add an extra triage label only if
-the user explicitly names one. Do not invent labels or an approval workflow —
-and don't promise a label that this repo's real label set (verified above)
-doesn't have.
+the user explicitly names one. Do not invent labels or an approval workflow.
 
 ### 5. Emit the ready-to-file body + report
 
@@ -103,7 +102,7 @@ report for the human to review:
 ```
 Issue pre-flight
 - Template: <file>
-- Labels: <label list actually applicable in this repo>
+- Labels: <label list>
 - Duplicate check: no matches found / possible match: <issue-url>
 - Command to open it: gh issue create --template <file> --label "<labels>"
 ```

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: issue-creation
+description: Create a well-formed GitHub issue in a Wazuh Dashboard repo — pick the right issue template, run an issue-first duplicate check, and produce a ready-to-file body with the template's default labels. Use when the user asks to create, open, file, or draft an issue.
+---
+
+# Create a wazuh-dashboard-alerting issue
+
+Pick the right issue template, check for duplicates first, then fill the
+template verbatim and hand off a ready-to-file body.
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] 1. Classify intent → choose issue template (ask only if ambiguous)
+- [ ] 2. Issue-first check: search existing issues for duplicates
+- [ ] 3. Fill the chosen .github/ISSUE_TEMPLATE/*.md verbatim
+- [ ] 4. Keep the template's default labels; add a triage label only if named
+- [ ] 5. Emit the ready-to-file body + report (default stop; gh issue create only if asked)
+```
+
+### 1. Classify intent → choose template
+
+Map the user's intent to a template. Ask the user only when genuinely
+ambiguous between two rows.
+
+| Intent | Template | Labels (from template frontmatter) |
+|--------|----------|--------|
+| Bug / defect report | `bug_report.md` | `bug, untriaged` |
+| New feature / enhancement request | `feature_request.md` | `enhancement, untriaged` |
+| New OpenSearch version compatibility tracking | `compatibility_request.md` | `request/operational, level/task, type/maintenance` |
+| Documentation gap or fix | `documentation.md` | *(none — see note below)* |
+
+### 2. Issue-first duplicate check
+
+Before drafting, search for an existing issue covering the same problem:
+
+```bash
+gh issue list --search "<keywords>"
+gh search issues "<keywords>" --repo wazuh/wazuh-dashboard-alerting
+```
+
+On a likely match, surface it to the user and ask whether to proceed with a
+new issue or comment on the existing one instead.
+
+### 3. Fill the template
+
+Reference the chosen file under
+[`.github/ISSUE_TEMPLATE`](../../../.github/ISSUE_TEMPLATE) — read it first and
+fill it verbatim; do not inline template bodies in this skill.
+
+> **repo-specific (wazuh-dashboard-alerting):** `bug_report.md` and
+> `feature_request.md` are upstream-inherited templates with full frontmatter
+> (`name`, `about`, `title`, `labels`) and are shown as chooser cards. Their
+> claimed labels are **partly stale**: this repo's real label set (`gh label
+> list`) has no `bug` or `enhancement` label — only the Wazuh taxonomy
+> (`type/bug`, `type/enhancement`, `level/*`, `reporter/*`,
+> `request/operational`, `untriaged`). GitHub silently drops a template label
+> that doesn't exist in the repo, so filing via `bug_report.md` only actually
+> attaches `untriaged` (not `bug`); `feature_request.md` likewise only attaches
+> `untriaged` (not `enhancement`). Manually add the real `type/bug` /
+> `type/enhancement` label during triage if you want that classification to
+> stick — don't claim `bug`/`enhancement` will be applied automatically.
+>
+> `compatibility_request.md` is accurate: all three of its labels
+> (`request/operational`, `level/task`, `type/maintenance`) exist in the repo
+> and its title is a template you fill in (`Compatibility with OpenSearch
+> (version)`), not a `[PREFIX]` tag.
+>
+> `documentation.md` has **no frontmatter at all** — no `name`/`about`/`title`/
+> `labels` — so it won't show as a chooser card and applies no default label.
+> It is not really meant for a person to file manually here: the
+> `.github/workflows/create-documentation-issue.yml` workflow appends a PR link
+> to it and files it as an issue in the **upstream**
+> `opensearch-project/documentation-website` repo (label `documentation`,
+> title `Add documentation related to new feature`) whenever a PR in this repo
+> is labeled `needs-documentation`. If the user wants a documentation issue
+> filed in *this* repo instead, use `documentation.md`'s body as free-form
+> content with no default labels.
+>
+> [`config.yml`](../../../.github/ISSUE_TEMPLATE/config.yml) only declares
+> `contact_links` (OpenSearch community support, AWS/Amazon security
+> reporting) — it does **not** set `blank_issues_enabled: false`, so blank
+> issues remain allowed alongside the templates. Regardless of template,
+> `.github/workflows/add-untriaged.yml` auto-applies the `untriaged` label to
+> every new issue on open/reopen/transfer — so the actual end-state label set
+> always includes `untriaged`, even where the template's own frontmatter can't
+> deliver it.
+
+### 4. Labels
+
+Keep the template's default labels as-is; add an extra triage label only if
+the user explicitly names one. Do not invent labels or an approval workflow —
+and don't promise a label that this repo's real label set (verified above)
+doesn't have.
+
+### 5. Emit the ready-to-file body + report
+
+**Default deliverable — stop here.** Output the filled issue body plus a short
+report for the human to review:
+
+```
+Issue pre-flight
+- Template: <file>
+- Labels: <label list actually applicable in this repo>
+- Duplicate check: no matches found / possible match: <issue-url>
+- Command to open it: gh issue create --template <file> --label "<labels>"
+```
+
+Only run `gh issue create` when the user explicitly asks you to open the
+issue.

--- a/.claude/skills/issue-creation/SKILL.md
+++ b/.claude/skills/issue-creation/SKILL.md
@@ -16,7 +16,7 @@ Copy this checklist and track progress:
 - [ ] 1. Classify intent → choose issue template (ask only if ambiguous)
 - [ ] 2. Issue-first check: search existing issues for duplicates
 - [ ] 3. Fill the chosen .github/ISSUE_TEMPLATE/*.md verbatim
-- [ ] 4. Keep the template's default labels; add a triage label only if named
+- [ ] 4. Apply the real Wazuh label for the intent (`type/bug` / `type/enhancement` / `level/task`) + `untriaged`; ignore stale frontmatter labels
 - [ ] 5. Emit the ready-to-file body + report (default stop; gh issue create only if asked)
 ```
 
@@ -54,15 +54,8 @@ fill it verbatim; do not inline template bodies in this skill.
 > **repo-specific (wazuh-dashboard-alerting):** `bug_report.md` and
 > `feature_request.md` are upstream-inherited templates with full frontmatter
 > (`name`, `about`, `title`, `labels`) and are shown as chooser cards. Their
-> claimed labels are **partly stale**: this repo's real label set (`gh label
-> list`) has no `bug` or `enhancement` label — only the Wazuh taxonomy
-> (`type/bug`, `type/enhancement`, `level/*`, `reporter/*`,
-> `request/operational`, `untriaged`). GitHub silently drops a template label
-> that doesn't exist in the repo, so filing via `bug_report.md` only actually
-> attaches `untriaged` (not `bug`); `feature_request.md` likewise only attaches
-> `untriaged` (not `enhancement`). Manually add the real `type/bug` /
-> `type/enhancement` label during triage if you want that classification to
-> stick — don't claim `bug`/`enhancement` will be applied automatically.
+> claimed `bug`/`enhancement` labels are stale — see step 4 for the real
+> labels to apply.
 >
 > `compatibility_request.md` is accurate: all three of its labels
 > (`request/operational`, `level/task`, `type/maintenance`) exist in the repo
@@ -91,8 +84,21 @@ fill it verbatim; do not inline template bodies in this skill.
 
 ### 4. Labels
 
-Keep the template's default labels as-is; add an extra triage label only if
-the user explicitly names one. Do not invent labels or an approval workflow.
+Several issue templates in this repo were inherited from the upstream
+OpenSearch Dashboards fork and still declare stale labels in their
+frontmatter (bare `bug`, `enhancement`) that don't exist as real labels here
+— GitHub silently drops any label that doesn't exist instead of erroring, so
+filing the template as-is can result in no type label at all. Standardize on
+the real Wazuh label set instead of trusting the frontmatter verbatim:
+
+| Intent | Real label to apply |
+|--------|--------|
+| Bug / defect | `type/bug` |
+| Feature / enhancement | `type/enhancement` |
+| Engineering task / chore | `level/task` |
+| Every issue | `untriaged` — applied automatically on open/reopen/transfer by `.github/workflows/add-untriaged.yml`, no manual action needed |
+
+Do not invent labels beyond this set, and do not invent an approval workflow.
 
 ### 5. Emit the ready-to-file body + report
 

--- a/.claude/skills/resolve-cve/SKILL.md
+++ b/.claude/skills/resolve-cve/SKILL.md
@@ -96,9 +96,10 @@ Then invoke **create-pr** in its default prepare-and-hand-off mode. It applies t
 shared rules automatically:
 
 - Base = the version branch the work started from (not always `main`).
-- CVE issues usually live in **`internal-devel-requests`** → "Issues Resolved"
-  left empty and **no CHANGELOG entry**. If the CVE issue is public, use `closes`
-  and add a CHANGELOG entry (under `Fixed`/`Changed`) linking the **issue**.
+- CVE issues usually live in **`internal-devel-requests`** → `## Description`
+  gets no closing reference and **no CHANGELOG entry**. If the CVE issue is
+  public, use `Closes #<n>` and add a CHANGELOG entry (under `Fixed`/`Changed`)
+  linking the **issue**.
 - Commits DCO-signed.
 
 Suggested PR title: `Fix <CVE-id>: bump <package> to <safe-version>`.

--- a/.github/ISSUE_TEMPLATE/task_template.md
+++ b/.github/ISSUE_TEMPLATE/task_template.md
@@ -1,0 +1,25 @@
+---
+name: 🛠️ Task
+about: Track an engineering task or improvement (not a bug, feature request, or documentation gap)
+title: ''
+labels: level/task
+assignees: ''
+---
+
+## Description
+
+<!--
+Describe the task: what needs to change and why. Include relevant context.
+-->
+
+### Code references
+
+<!--
+Link the relevant code locations that give context for this task, for example:
+
+https://github.com/wazuh/wazuh-dashboard-alerting/blob/<commit>/<path>#L<line>
+-->
+
+## Tasks
+
+- [ ] <!-- List the concrete, actionable steps needed to complete this task -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,77 @@
-### Description
-[Describe what this change achieves]
- 
-### Issues Resolved
-[List any issues this PR will resolve]
- 
-### Check List
-- [ ] New functionality includes testing.
-  - [ ] All tests pass
-- [ ] New functionality has been documented.
-  - [ ] New functionality has javadoc added
-- [ ] Commits are signed per the DCO using --signoff 
+## Description
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+<!--
+Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
+
+If this pull request resolves an existing issue, reference it here. For example:
+Closes #<issue_number>
+-->
+
+## Proposed Changes
+
+<!--
+Summarize the changes made in this pull request. Include:
+- Features added
+- Bugs fixed
+- Any relevant technical details
+-->
+
+### Results and Evidence
+
+<!--
+Provide evidence of the changes made, such as:
+- Logs
+- Screenshots
+- Before/after comparisons
+-->
+
+### Artifacts Affected
+
+<!--
+List the artifacts impacted by this pull request, such as:
+- Executables (specify platforms if applicable)
+- Default configuration files
+- Packages
+-->
+
+### Configuration Changes
+
+<!--
+If applicable, list any configuration changes introduced by this pull request, including:
+- New configuration parameters
+- Changes to default values
+- Backward compatibility notes
+-->
+
+### Documentation Updates
+
+<!--
+If applicable, list the sections of documentation that have been updated as part of this pull request.
+-->
+
+### Tests Introduced
+
+<!--
+If applicable, describe any new unit or integration tests added as part of this pull request. Include:
+- Scope of the tests
+- Any relevant details about test coverage
+-->
+
+### How to Test
+
+<!--
+Describe the manual steps a reviewer can follow to verify this change works, such as:
+- Steps to reproduce/validate the change
+- Environment or setup needed (branch, data, feature flags, etc.)
+- Expected result
+-->
+
+### Review Checklist
+
+- [ ] All tests pass
+  - [ ] `yarn test:jest`
+  - [ ] `yarn cypress:run:ci`
+- [ ] New functionality includes testing.
+- [ ] New functionality has been documented.
+- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
+- [ ] Commits are signed per the DCO using --signoff

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,21 +57,19 @@ If applicable, describe any new unit or integration tests added as part of this 
 - Any relevant details about test coverage
 -->
 
-### How to Test
+## Review Checklist
 
 <!--
-Describe the manual steps a reviewer can follow to verify this change works, such as:
-- Steps to reproduce/validate the change
-- Environment or setup needed (branch, data, feature flags, etc.)
-- Expected result
+List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
 -->
 
-### Review Checklist
-
-- [ ] All tests pass
-  - [ ] `yarn test:jest`
-  - [ ] `yarn cypress:run:ci`
-- [ ] New functionality includes testing.
-- [ ] New functionality has been documented.
-- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
-- [ ] Commits are signed per the DCO using --signoff
+- [ ] Code changes reviewed
+- [ ] Relevant evidence provided
+- [ ] Tests cover the new functionality
+- [ ] Configuration changes documented
+- [ ] Developer documentation reflects the changes
+- [ ] Meets requirements and/or definition of done
+- [ ] No unresolved dependencies with other issues
+- [ ] PR is linked to the relevant issue(s)
+- [ ] Correct labels applied (e.g., `no-changelog`)
+- [ ] ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,8 +173,9 @@ Shared Wazuh Dashboard conventions:
 - **Sign commits** (DCO `--signoff`). Imperative, capitalized subject.
 - Open PRs as **Draft** (CI skips drafts); run lint + tests locally, then "Ready
   for review". Squash merge for single-purpose PRs.
-- UI changes require a screenshot/video in the PR (the template is
-  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)).
+- UI changes require a screenshot/video in the PR (`### Results and Evidence`
+  section of the [PR template](.github/PULL_REQUEST_TEMPLATE.md)); manual
+  verification steps go in `### How to Test`.
 - **Changelog:** maintain [`CHANGELOG.md`](CHANGELOG.md) by hand for user-facing
   changes; entries **link to the issue, not the PR** (many historical entries link
   to PRs — prefer the issue link for new work). No entry for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ Shared Wazuh Dashboard conventions:
   `internal-devel-requests` issues or tooling/docs/test-only PRs.
 - Issues arrive as URLs and may live in another repo. Issues from
   `internal-devel-requests` are internal: don't expose their link in the PR
-  ("Issues Resolved" empty) and add no CHANGELOG entry.
+  (no closing reference in `## Description`) and add no CHANGELOG entry.
 
 ## Fork coexistence
 


### PR DESCRIPTION
## Description

Related to wazuh/wazuh-dashboard#1446. This is the `wazuh-dashboard-alerting` counterpart of the cross-repo initiative to add a repo-local `issue-creation` skill and de-duplicate the PR template, replicated across all Wazuh Dashboard repositories.

## Proposed Changes

- Added `.claude/skills/issue-creation/SKILL.md`: classifies intent, maps to the right real issue template, runs an issue-first duplicate check, and fills the template verbatim with this repo's real default labels — no invented labels or workflow. Standardized to the same structure/wording used across every Wazuh Dashboard repo in this cross-repo initiative. Documents two repo-specific gotchas: `bug_report.md`/`feature_request.md` claim `bug`/`enhancement` labels that don't exist here (only `type/bug`/`type/enhancement` do, confirmed via `gh label list`), and `documentation.md` is actually consumed by the `create-documentation-issue.yml` workflow to file a doc issue in the upstream `opensearch-project/documentation-website` repo, not a normal chooser template.
- Added `.github/ISSUE_TEMPLATE/task_template.md` for generic engineering tasks (label: `level/task`).
- Rewrote `.github/PULL_REQUEST_TEMPLATE.md` to the new structure, replacing the old `### Description` / `### Issues Resolved` / `### Check List` structure. The Review Checklist's test sub-bullets reference this repo's real scripts: `yarn test:jest` and `yarn cypress:run:ci`.
- De-duplicated `.claude/skills/create-pr/SKILL.md`: it no longer inlines the PR template's sections — it now points to `.github/PULL_REQUEST_TEMPLATE.md` and instructs reading/filling it verbatim. Updated the issue-source logic to reference `## Description` instead of the old `### Issues Resolved` section, and changed the `gh pr create` example to use `--body-file` instead of an inlined heredoc.
- Fixed stale references to the old template's section names in `CLAUDE.md`, `.claude/skills/develop-issue/SKILL.md`, and `.claude/skills/resolve-cve/SKILL.md`.

### Results and Evidence

Ran a full self-verification pass: repo-wide grep for the old section names (zero hits), and cross-checked every label claimed in the `issue-creation` skill — including the new `task_template.md` row — against `gh label list --repo wazuh/wazuh-dashboard-alerting`.

### Artifacts Affected

- `.github/PULL_REQUEST_TEMPLATE.md`
- `.claude/skills/create-pr/SKILL.md`
- `.claude/skills/develop-issue/SKILL.md`
- `.claude/skills/resolve-cve/SKILL.md`
- `CLAUDE.md`
- `.claude/skills/issue-creation/SKILL.md` (new)
- `.github/ISSUE_TEMPLATE/task_template.md` (new)

No production code, configuration, or packaging artifacts are affected — this is a docs/AI-tooling-only change.

### Configuration Changes

None.

### Documentation Updates

`.github/PULL_REQUEST_TEMPLATE.md` restructured; `CLAUDE.md` and three `.claude/skills/*/SKILL.md` files updated to match. `issue-creation/SKILL.md` follows the same structure standardized across every repo in this initiative.

### Tests Introduced

None — this change touches only Markdown templates and Claude skill docs, no runtime code.

### How to Test

1. Check out this branch.
2. Open `.github/PULL_REQUEST_TEMPLATE.md` and confirm it matches the new structure and that its test commands (`yarn test:jest`, `yarn cypress:run:ci`) are real `package.json` scripts.
3. Grep the repo for `"### Issues Resolved"`, `"### Check List"`, and `"### Description"` — expect zero hits outside historical git history.
4. Read `.claude/skills/issue-creation/SKILL.md` and cross-check its label table (including `task_template.md`) against `.github/ISSUE_TEMPLATE/*.md` frontmatter and `gh label list --repo wazuh/wazuh-dashboard-alerting`.

### Review Checklist

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn cypress:run:ci`
- [x] New functionality includes testing. (N/A — docs/tooling-only, no runtime surface to test)
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md) — skipped: this is a docs/tooling-only change (AI skill docs + PR/issue templates) with no user-facing dashboard impact (`no-changelog` label applied).
- [x] Commits are signed per the DCO using --signoff
