### PR TITLE
Apply the typed index on blur in the monitor index field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Support for Wazuh 5.0.0
 - Added debounce to Document Level Query text inputs
-- Add "Active Response" monitor type [#33](https://github.com/wazuh/wazuh-dashboard-alerting/pull/33)
+- Add "Active Response" monitor type [#33](https://github.com/wazuh/wazuh-dashboard-alerting/pull/33) [#133](https://github.com/wazuh/wazuh-dashboard-alerting/issues/133) 
 
 ### Changed
 

--- a/public/components/FormControls/FormikComboBox/FormikComboBox.js
+++ b/public/components/FormControls/FormikComboBox/FormikComboBox.js
@@ -36,9 +36,12 @@ const ComboBox = ({
   name,
   form,
   field,
-  inputProps: { onBlur, onChange, onCreateOption, ...rest },
+  // Wazuh: `comboBoxRef` gives the consumer access to the combo box instance, which is needed to
+  // reset the search input imperatively.
+  inputProps: { onBlur, onChange, onCreateOption, comboBoxRef, ...rest },
 }) => (
   <EuiCompressedComboBox
+    ref={comboBoxRef}
     name={name}
     id={name}
     onChange={

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -57,6 +57,9 @@ class MonitorIndex extends React.Component {
     // Wazuh: combo box instance, used to reset its search input once the typed text is applied.
     this.comboBox = null;
     this.setComboBoxRef = (comboBox) => (this.comboBox = comboBox);
+    // Wazuh: every index, data stream and alias the searches have resolved, so that validating one
+    // of them does not have to ask the cluster again.
+    this.resolvedIndices = new Set();
     this.state = {
       isLoading: false,
       appendedWildcard: false,
@@ -137,6 +140,8 @@ class MonitorIndex extends React.Component {
    * or an alias. Used to validate an index that was typed instead of picked from the options.
    */
   async indexExists(index) {
+    if (this.resolvedIndices.has(index)) return true;
+
     const { indices, dataStreamAliases } = await this.handleQueryIndices(index);
     if (indices.length || dataStreamAliases.length) return true;
 
@@ -158,6 +163,10 @@ class MonitorIndex extends React.Component {
         this.setState({ appendedWildcard: false });
       }
     }
+
+    // Wazuh: resetting the search input asks for the same query again, and it is reset twice per
+    // applied index, once by this component and once by the combo box itself.
+    if (query === this.lastQuery) return;
 
     this.lastQuery = query;
     this.setState({ query, showingIndexPatternQueryErrors: !!query.length });
@@ -203,9 +212,11 @@ class MonitorIndex extends React.Component {
             if (!dataStreamsSet.has(dsName)) {
               dataStreamsSet.add(dsName);
               dataStreamAliases.push({ label: dsName });
+              this.resolvedIndices.add(dsName); // Wazuh
             }
           } else {
             indices.push({ label: idx, health, status });
+            this.resolvedIndices.add(idx); // Wazuh
           }
         });
 
@@ -241,6 +252,7 @@ class MonitorIndex extends React.Component {
 
       if (response.ok) {
         const indices = response.resp.map(({ alias, index }) => ({ label: alias, index }));
+        indices.forEach(({ label }) => this.resolvedIndices.add(label)); // Wazuh
         return _.sortBy(indices, 'label');
       }
       return [];

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -9,7 +9,13 @@ import _ from 'lodash';
 import { EuiHealth, EuiHighlight } from '@elastic/eui';
 
 import { FormikComboBox } from '../../../../components/FormControls';
-import { validateIndex, hasError, isInvalid } from '../../../../utils/validate';
+import {
+  hasError,
+  isActiveResponseFindingsIndex,
+  isInvalid,
+  validateActiveResponseIndex,
+  validateIndex,
+} from '../../../../utils/validate';
 import { canAppendWildcard, createReasonableWait, getMatchedOptions } from './utils/helpers';
 import { ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN, MONITOR_TYPE } from '../../../../utils/constants';
 import CrossClusterConfiguration from '../../components/CrossClusterConfigurations/containers';
@@ -46,6 +52,11 @@ class MonitorIndex extends React.Component {
   constructor(props) {
     super(props);
     this.lastQuery = null;
+    // Wazuh: text currently typed in the combo box search input, kept so it can be applied on blur.
+    this.searchValue = '';
+    // Wazuh: combo box instance, used to reset its search input once the typed text is applied.
+    this.comboBox = null;
+    this.setComboBoxRef = (comboBox) => (this.comboBox = comboBox);
     this.state = {
       isLoading: false,
       appendedWildcard: false,
@@ -72,28 +83,60 @@ class MonitorIndex extends React.Component {
   }
 
   componentDidMount() {
-    this.onSearchChange(this.getInitialSearchQuery());
+    // Wazuh: the search input starts empty, `onSearchChange` falls back to the initial query.
+    this.onSearchChange('');
   }
 
   componentDidUpdate(prevProps) {
     if (isDataSourceChanged(prevProps, this.props)) {
-      this.onSearchChange(this.getInitialSearchQuery());
+      this.onSearchChange('');
     }
   }
 
   onCreateOption(searchValue, selectedOptions, setFieldValue, supportMultipleIndices) {
-    const normalizedSearchValue = searchValue.trim().toLowerCase();
+    const newOption = { label: searchValue.trim() };
 
-    if (!normalizedSearchValue) return;
+    if (!newOption.label) return;
 
-    const newOption = { label: searchValue };
-    if (supportMultipleIndices) setFieldValue('index', selectedOptions.concat(newOption));
-    else setFieldValue('index', [newOption]);
+    // Wazuh: the monitor form does not validate on change, so validation is requested explicitly.
+    // Otherwise the error of the index being replaced stays on screen until the next interaction.
+    if (supportMultipleIndices) setFieldValue('index', selectedOptions.concat(newOption), true);
+    else setFieldValue('index', [newOption], true);
+  }
+
+  /**
+   * Wazuh: apply the text left in the search input when the combo box loses focus.
+   *
+   * The combo box only turns typed text into a selection on blur while none of its options is
+   * active, and single selection pickers (Active Response and per document monitors) keep an
+   * option active once one is selected, which silently discarded the typed index.
+   *
+   * @returns {boolean} whether the typed text was applied.
+   */
+  commitPendingSearchValue(selectedOptions, form, supportMultipleIndices) {
+    if (!this.searchValue.trim()) return false;
+
+    this.onCreateOption(
+      this.searchValue,
+      selectedOptions,
+      form.setFieldValue,
+      supportMultipleIndices
+    );
+
+    // Reset the search input, otherwise the combo box keeps rendering the typed text as invalid
+    // instead of the index that was just applied.
+    if (this.comboBox?.clearSearchValue) this.comboBox.clearSearchValue();
+    else this.searchValue = '';
+
+    return true;
   }
 
   async onSearchChange(searchValue) {
     const { appendedWildcard } = this.state;
-    let query = searchValue;
+    this.searchValue = searchValue;
+    // Wazuh: the combo box clears its search input after applying a value. Falling back to the
+    // initial query keeps the index options list populated instead of emptying it.
+    let query = searchValue || this.getInitialSearchQuery();
     if (query.length === 1 && canAppendWildcard(query)) {
       query += '*';
       this.setState({ appendedWildcard: true });
@@ -262,12 +305,23 @@ class MonitorIndex extends React.Component {
     );
 
     // Wazuh: restrict index options to findings indices for Active Response monitors
-    if (this.props.monitorType === MONITOR_TYPE.ACTIVE_RESPONSE) {
-      const isFindingsIndex = (o) => o.label.startsWith('wazuh-findings');
+    const isActiveResponse = this.props.monitorType === MONITOR_TYPE.ACTIVE_RESPONSE;
+    if (isActiveResponse) {
       visibleOptions = visibleOptions
-        .map((group) => ({ ...group, options: group.options.filter(isFindingsIndex) }))
+        .map((group) => ({
+          ...group,
+          options: group.options.filter(({ label }) => isActiveResponseFindingsIndex(label)),
+        }))
         .filter((group) => group.options.length > 0);
     }
+
+    // Wazuh: a typed index bypasses the options list, so Active Response monitors validate the
+    // selected value against the indices this field offers.
+    const validateMonitorIndex = isActiveResponse
+      ? validateActiveResponseIndex(
+          _.flatMap(visibleOptions, ({ options }) => _.map(options, 'label'))
+        )
+      : validateIndex;
 
     let supportMultipleIndices = true;
     let supportsCrossClusterMonitoring = false;
@@ -293,7 +347,7 @@ class MonitorIndex extends React.Component {
           <FormikComboBox
             name="index"
             formRow
-            fieldProps={{ validate: validateIndex }}
+            fieldProps={{ validate: validateMonitorIndex }}
             rowProps={{
               label: 'Index',
               helpText:
@@ -307,8 +361,19 @@ class MonitorIndex extends React.Component {
               async: true,
               isLoading,
               options: visibleOptions,
+              comboBoxRef: this.setComboBoxRef,
               onBlur: (e, field, form) => {
-                form.setFieldTouched('index', true);
+                // Wazuh: apply the typed index, the combo box does not always do it.
+                const applied = this.commitPendingSearchValue(
+                  field.value,
+                  form,
+                  supportMultipleIndices
+                );
+                // Wazuh: `setFieldTouched` validates the value the form had when this handler
+                // started, so validating here after applying a value would bring the error of the
+                // previous value back until the next interaction. The value applied above asks for
+                // validation itself.
+                form.setFieldTouched('index', true, !applied);
               },
               onChange: (options, field, form) => {
                 form.setFieldValue('index', options);

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -73,6 +73,7 @@ class MonitorIndex extends React.Component {
     this.onSearchChange = this.onSearchChange.bind(this);
     this.handleQueryIndices = this.handleQueryIndices.bind(this);
     this.handleQueryAliases = this.handleQueryAliases.bind(this);
+    this.indexExists = this.indexExists.bind(this);
     this.onFetch = this.onFetch.bind(this);
   }
 
@@ -129,6 +130,19 @@ class MonitorIndex extends React.Component {
     else this.searchValue = '';
 
     return true;
+  }
+
+  /**
+   * Wazuh: whether an index can be monitored, i.e. whether it resolves to an index, a data stream
+   * or an alias. Used to validate an index that was typed instead of picked from the options.
+   */
+  async indexExists(index) {
+    const [{ indices, dataStreamAliases }, aliases] = await Promise.all([
+      this.handleQueryIndices(index),
+      this.handleQueryAliases(index),
+    ]);
+
+    return !!(indices.length || dataStreamAliases.length || aliases.length);
   }
 
   async onSearchChange(searchValue) {
@@ -315,12 +329,10 @@ class MonitorIndex extends React.Component {
         .filter((group) => group.options.length > 0);
     }
 
-    // Wazuh: a typed index bypasses the options list, so Active Response monitors validate the
-    // selected value against the indices this field offers.
+    // Wazuh: a typed index bypasses the options list, so Active Response monitors validate that the
+    // selected value is an existing findings index.
     const validateMonitorIndex = isActiveResponse
-      ? validateActiveResponseIndex(
-          _.flatMap(visibleOptions, ({ options }) => _.map(options, 'label'))
-        )
+      ? validateActiveResponseIndex(this.indexExists)
       : validateIndex;
 
     let supportMultipleIndices = true;
@@ -376,7 +388,9 @@ class MonitorIndex extends React.Component {
                 form.setFieldTouched('index', true, !applied);
               },
               onChange: (options, field, form) => {
-                form.setFieldValue('index', options);
+                // Wazuh: the form does not validate on change, so picking an index from the options
+                // would otherwise keep the error of the index it replaces until the next blur.
+                form.setFieldValue('index', options, true);
               },
               onCreateOption: (value, field, form) => {
                 this.onCreateOption(value, field.value, form.setFieldValue, supportMultipleIndices);

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -137,12 +137,10 @@ class MonitorIndex extends React.Component {
    * or an alias. Used to validate an index that was typed instead of picked from the options.
    */
   async indexExists(index) {
-    const [{ indices, dataStreamAliases }, aliases] = await Promise.all([
-      this.handleQueryIndices(index),
-      this.handleQueryAliases(index),
-    ]);
+    const { indices, dataStreamAliases } = await this.handleQueryIndices(index);
+    if (indices.length || dataStreamAliases.length) return true;
 
-    return !!(indices.length || dataStreamAliases.length || aliases.length);
+    return (await this.handleQueryAliases(index)).length > 0;
   }
 
   async onSearchChange(searchValue) {

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -6,30 +6,56 @@
 import React from 'react';
 import { Formik } from 'formik';
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
 import { FORMIK_INITIAL_VALUES } from '../CreateMonitor/utils/constants';
 import MonitorIndex from './MonitorIndex';
 import * as helpers from './utils/helpers';
 import { httpClientMock } from '../../../../../test/mocks';
+import { MONITOR_TYPE } from '../../../../utils/constants';
 
 helpers.createReasonableWait = jest.fn((cb) => cb());
-httpClientMock.post.mockResolvedValue({ ok: true, resp: [] });
 
 // Enzyme's change event is synchronous and Formik's handlers are asynchronous
 // https://github.com/formium/formik/issues/937, https://www.benmvp.com/blog/asynchronous-testing-with-enzyme-react-jest/
 const runAllPromises = () => new Promise(setImmediate);
 
+let formikProps;
+
 function getMountWrapper(customProps = {}) {
   return mount(
-    <Formik initialValues={FORMIK_INITIAL_VALUES}>
-      {() => <MonitorIndex httpClient={httpClientMock} {...customProps} />}
+    // `validateOnChange` is disabled to match the monitor form, see CreateMonitor.
+    <Formik initialValues={FORMIK_INITIAL_VALUES} validateOnChange={false}>
+      {(props) => {
+        formikProps = props;
+        return <MonitorIndex httpClient={httpClientMock} {...customProps} />;
+      }}
     </Formik>
   );
+}
+
+// The combo box applies typed text through a native `focusout` listener on its container, which
+// Enzyme's synthetic `simulate('blur')` does not reach.
+function blurComboBox(wrapper) {
+  const comboBox = wrapper.find('[data-test-subj="indicesComboBox"]').hostNodes().getDOMNode();
+  act(() => {
+    comboBox.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+  });
+  wrapper.update();
+}
+
+function typeInComboBox(wrapper, value) {
+  wrapper
+    .find('[data-test-subj="comboBoxSearchInput"]')
+    .hostNodes()
+    .simulate('change', { target: { value } });
 }
 
 describe('MonitorIndex', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // `clearMocks` only clears calls, so the response has to be restored to keep tests isolated.
+    httpClientMock.post.mockResolvedValue({ ok: true, resp: [] });
   });
   test('renders', () => {
     const wrapper = getMountWrapper();
@@ -96,7 +122,9 @@ describe('MonitorIndex', () => {
     const wrapper = getMountWrapper();
 
     expect(await wrapper.find(MonitorIndex).instance().handleQueryAliases('*:')).toEqual([]);
-    expect((await wrapper.find(MonitorIndex).instance().handleQueryIndices('*:')).indices).toEqual([]);
+    expect((await wrapper.find(MonitorIndex).instance().handleQueryIndices('*:')).indices).toEqual(
+      []
+    );
   });
 
   test('returns empty array for data.ok = false', async () => {
@@ -104,7 +132,9 @@ describe('MonitorIndex', () => {
     const wrapper = getMountWrapper();
 
     expect(await wrapper.find(MonitorIndex).instance().handleQueryAliases('random')).toEqual([]);
-    expect((await wrapper.find(MonitorIndex).instance().handleQueryIndices('random')).indices).toEqual([]);
+    expect(
+      (await wrapper.find(MonitorIndex).instance().handleQueryIndices('random')).indices
+    ).toEqual([]);
   });
   //
   test('returns indices/aliases', async () => {
@@ -122,20 +152,18 @@ describe('MonitorIndex', () => {
     ]);
   });
 
-  test.skip('onBlur sets index to touched', () => {
+  test('onBlur sets index to touched', async () => {
     httpClientMock.post.mockResolvedValue({
       ok: true,
       resp: [{ health: 'green', status: 'open', index: 'logstash-0', alias: 'logstash' }],
     });
     const wrapper = getMountWrapper();
 
-    wrapper
-      .find('[data-test-subj="comboBoxSearchInput"]')
-      .hostNodes()
-      .simulate('change', { target: { value: 'l' } })
-      .simulate('blur');
+    typeInComboBox(wrapper, 'l');
+    await runAllPromises();
+    blurComboBox(wrapper);
 
-    expect(wrapper.instance().state.touched).toEqual({ index: true });
+    expect(formikProps.touched).toEqual({ index: true });
   });
 
   test('sets option when calling onCreateOption', async () => {
@@ -162,5 +190,61 @@ describe('MonitorIndex', () => {
     expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual(
       'logstash-0EuiIconMock'
     );
+  });
+
+  test('applies the typed index on blur', async () => {
+    const wrapper = getMountWrapper({ monitorType: MONITOR_TYPE.DOC_LEVEL });
+
+    // Leaving the field without an index reports the error.
+    blurComboBox(wrapper);
+    await runAllPromises();
+    expect(formikProps.errors.index).toBe('Must specify an index.');
+
+    typeInComboBox(wrapper, 'logstash-0');
+    await runAllPromises();
+    blurComboBox(wrapper);
+    await runAllPromises();
+
+    expect(formikProps.values.index).toEqual([{ label: 'logstash-0' }]);
+    // The error of the index that was replaced must not survive the blur.
+    expect(formikProps.errors.index).toBeUndefined();
+    // The typed text is applied, so the search input no longer holds it.
+    expect(wrapper.find('[data-test-subj="comboBoxSearchInput"]').hostNodes().prop('value')).toBe(
+      ''
+    );
+  });
+
+  test('rejects indices Active Response monitors cannot run over', async () => {
+    httpClientMock.post.mockImplementation((url) =>
+      Promise.resolve({
+        ok: true,
+        resp: url.includes('_aliases')
+          ? []
+          : [{ health: 'green', status: 'open', index: 'wazuh-findings-v5-000001' }],
+      })
+    );
+    const wrapper = getMountWrapper({ monitorType: MONITOR_TYPE.ACTIVE_RESPONSE });
+
+    const typeAndBlur = async (value) => {
+      typeInComboBox(wrapper, value);
+      await runAllPromises();
+      blurComboBox(wrapper);
+      await runAllPromises();
+      // The typed index is always applied, so that it is never taken for a discarded one.
+      expect(formikProps.values.index.map(({ label }) => label)).toEqual([value]);
+    };
+
+    await typeAndBlur('logstash-0');
+    expect(formikProps.errors.index).toMatch('can only use Wazuh findings indices');
+
+    await typeAndBlur('wazuh-findings-v5-*');
+    expect(formikProps.errors.index).toMatch('Index patterns are not supported');
+
+    // A findings index that the field does not offer does not exist.
+    await typeAndBlur('wazuh-findings-v5-000009');
+    expect(formikProps.errors.index).toMatch('Select one of the available findings indices');
+
+    await typeAndBlur('wazuh-findings-v5-000001');
+    expect(formikProps.errors.index).toBeUndefined();
   });
 });

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -214,18 +214,26 @@ describe('MonitorIndex', () => {
     );
   });
 
-  test('rejects indices Active Response monitors cannot run over', async () => {
-    httpClientMock.post.mockImplementation((url) =>
-      Promise.resolve({
-        ok: true,
-        resp: url.includes('_aliases')
-          ? []
-          : [{ health: 'green', status: 'open', index: 'wazuh-findings-v5-000001' }],
-      })
-    );
-    const wrapper = getMountWrapper({ monitorType: MONITOR_TYPE.ACTIVE_RESPONSE });
+  describe('Active Response monitors', () => {
+    // Only this index exists, so the queries of any other one come back empty.
+    const EXISTING_INDEX = 'wazuh-findings-v5-000001';
 
-    const typeAndBlur = async (value) => {
+    beforeEach(() => {
+      httpClientMock.post.mockImplementation((url, { body }) => {
+        const { index, alias } = JSON.parse(body);
+        const query = index || alias;
+        const matches = query.endsWith('*')
+          ? EXISTING_INDEX.startsWith(query.slice(0, -1))
+          : EXISTING_INDEX === query;
+        const resp =
+          matches && !url.includes('_aliases')
+            ? [{ health: 'green', status: 'open', index: EXISTING_INDEX }]
+            : [];
+        return Promise.resolve({ ok: true, resp });
+      });
+    });
+
+    const typeAndBlur = async (wrapper, value) => {
       typeInComboBox(wrapper, value);
       await runAllPromises();
       blurComboBox(wrapper);
@@ -234,17 +242,34 @@ describe('MonitorIndex', () => {
       expect(formikProps.values.index.map(({ label }) => label)).toEqual([value]);
     };
 
-    await typeAndBlur('logstash-0');
-    expect(formikProps.errors.index).toMatch('can only use Wazuh findings indices');
+    test('reject the indices they cannot run over', async () => {
+      const wrapper = getMountWrapper({ monitorType: MONITOR_TYPE.ACTIVE_RESPONSE });
 
-    await typeAndBlur('wazuh-findings-v5-*');
-    expect(formikProps.errors.index).toMatch('Index patterns are not supported');
+      await typeAndBlur(wrapper, 'logstash-0');
+      expect(formikProps.errors.index).toMatch('can only use Wazuh findings indices');
 
-    // A findings index that the field does not offer does not exist.
-    await typeAndBlur('wazuh-findings-v5-000009');
-    expect(formikProps.errors.index).toMatch('Select one of the available findings indices');
+      await typeAndBlur(wrapper, 'wazuh-findings-v5-*');
+      expect(formikProps.errors.index).toMatch('Index patterns are not supported');
 
-    await typeAndBlur('wazuh-findings-v5-000001');
-    expect(formikProps.errors.index).toBeUndefined();
+      await typeAndBlur(wrapper, 'wazuh-findings-v5-000009');
+      expect(formikProps.errors.index).toMatch('Index not found');
+
+      await typeAndBlur(wrapper, EXISTING_INDEX);
+      expect(formikProps.errors.index).toBeUndefined();
+    });
+
+    test('clear the error when an index is picked from the options', async () => {
+      const wrapper = getMountWrapper({ monitorType: MONITOR_TYPE.ACTIVE_RESPONSE });
+
+      await typeAndBlur(wrapper, 'wazuh-findings-v5-000009');
+      expect(formikProps.errors.index).toMatch('Index not found');
+
+      // Picking an index has to report on its own, the form does not validate on change.
+      wrapper.find('EuiCompressedComboBox').prop('onChange')([{ label: EXISTING_INDEX }]);
+      await runAllPromises();
+
+      expect(formikProps.values.index).toEqual([{ label: EXISTING_INDEX }]);
+      expect(formikProps.errors.index).toBeUndefined();
+    });
   });
 });

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -81,6 +81,7 @@ exports[`MonitorIndex renders 1`] = `
       },
     }
   }
+  validateOnChange={false}
 >
   <MonitorIndex
     httpClient={[MockFunction]}
@@ -95,6 +96,7 @@ exports[`MonitorIndex renders 1`] = `
       inputProps={
         Object {
           "async": true,
+          "comboBoxRef": [Function],
           "data-test-subj": "indicesComboBox",
           "delimiter": ",",
           "isClearable": true,
@@ -258,7 +260,7 @@ exports[`MonitorIndex renders 1`] = `
                 "validateField": [Function],
                 "validateForm": [Function],
                 "validateOnBlur": true,
-                "validateOnChange": true,
+                "validateOnChange": false,
                 "validateOnMount": false,
                 "values": Object {
                   "aggregationType": "count",
@@ -524,7 +526,7 @@ exports[`MonitorIndex renders 1`] = `
                         "validateField": [Function],
                         "validateForm": [Function],
                         "validateOnBlur": true,
-                        "validateOnChange": true,
+                        "validateOnChange": false,
                         "validateOnMount": false,
                         "values": Object {
                           "aggregationType": "count",
@@ -609,6 +611,7 @@ exports[`MonitorIndex renders 1`] = `
                     inputProps={
                       Object {
                         "async": true,
+                        "comboBoxRef": [Function],
                         "data-test-subj": "indicesComboBox",
                         "delimiter": ",",
                         "isClearable": true,

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -38,8 +38,11 @@ export const MONITOR_TYPE = {
   ACTIVE_RESPONSE: 'active_response_monitor', // Wazuh
 };
 
+// Wazuh: Prefix shared by every findings index Active Response monitors are allowed to run over
+export const ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX = 'wazuh-findings';
+
 // Wazuh: Index pattern for findings indices used by Active Response monitors
-export const ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN = 'wazuh-findings*';
+export const ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN = `${ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX}*`;
 
 export const DESTINATION_ACTIONS = {
   UPDATE_DESTINATION: 'update-destination',

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -174,35 +174,33 @@ export const isActiveResponseFindingsIndex = (label = '') =>
   label.trim().toLowerCase().startsWith(ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX);
 
 /**
- * Wazuh: Active Response monitors can only run over one of the findings indices the index field
- * offers. Being document level monitors they do not support index patterns either, and a typed
- * index is applied as it was typed, so the value itself has to be validated to tell the user that
- * what they typed is not usable instead of letting them believe it was accepted.
+ * Wazuh: Active Response monitors can only run over an existing Wazuh findings index. Being
+ * document level monitors they do not support index patterns either, and a typed index is applied
+ * as it was typed, so the value itself has to be validated to tell the user that what they typed
+ * is not usable instead of letting them believe it was accepted.
  *
- * @param availableIndices labels of the indices offered by the index field.
+ * @param indexExists resolves whether an index can be monitored. Existence is asked for instead of
+ * matched against the options the index field shows, which only hold the last search results.
  */
-export const validateActiveResponseIndex =
-  (availableIndices = []) =>
-  (options) => {
-    const genericError = validateIndex(options);
-    if (genericError) return genericError;
+export const validateActiveResponseIndex = (indexExists) => async (options) => {
+  const genericError = validateIndex(options);
+  if (genericError) return genericError;
 
-    const indices = options.map(({ value, label }) => value || label);
+  const indices = options.map(({ value, label }) => value || label);
 
-    if (!indices.every(isActiveResponseFindingsIndex)) {
-      return `Active Response monitors can only use Wazuh findings indices (must start with "${ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX}").`;
-    }
+  if (!indices.every(isActiveResponseFindingsIndex)) {
+    return `Active Response monitors can only use Wazuh findings indices (must start with "${ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX}").`;
+  }
 
-    if (indices.some((index) => index.includes('*'))) {
-      return 'Index patterns are not supported. Select a single findings index.';
-    }
+  if (indices.some((index) => index.includes('*'))) {
+    return 'Index patterns are not supported. Select a single findings index.';
+  }
 
-    // The available indices are unknown until the index field has loaded them, and an index that is
-    // not among them cannot be monitored.
-    if (availableIndices.length && indices.some((index) => !availableIndices.includes(index))) {
-      return 'Select one of the available findings indices.';
-    }
-  };
+  const existence = await Promise.all(indices.map(indexExists));
+  if (existence.some((exists) => !exists)) {
+    return 'Index not found. Select one of the available findings indices.';
+  }
+};
 
 export function isIndexPatternQueryValid(pattern, illegalCharacters) {
   if (!pattern || !pattern.length) {

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -5,7 +5,7 @@
 
 import _ from 'lodash';
 import { INDEX, MAX_THROTTLE_VALUE, WRONG_THROTTLE_WARNING } from '../../utils/constants';
-import { MONITOR_TYPE } from './constants';
+import { ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX, MONITOR_TYPE } from './constants';
 import { TRIGGER_TYPE } from '../pages/CreateTrigger/containers/CreateTrigger/utils/constants';
 import { getDataSourceQueryObj } from '../pages/utils/helpers';
 
@@ -168,6 +168,41 @@ export const validateIndex = (options) => {
     return `One of your inputs contains invalid characters or spaces. Please omit: ${illegalCharacters}`;
   }
 };
+
+// Wazuh: an index belongs to the Wazuh findings indices when it starts with the findings prefix.
+export const isActiveResponseFindingsIndex = (label = '') =>
+  label.trim().toLowerCase().startsWith(ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX);
+
+/**
+ * Wazuh: Active Response monitors can only run over one of the findings indices the index field
+ * offers. Being document level monitors they do not support index patterns either, and a typed
+ * index is applied as it was typed, so the value itself has to be validated to tell the user that
+ * what they typed is not usable instead of letting them believe it was accepted.
+ *
+ * @param availableIndices labels of the indices offered by the index field.
+ */
+export const validateActiveResponseIndex =
+  (availableIndices = []) =>
+  (options) => {
+    const genericError = validateIndex(options);
+    if (genericError) return genericError;
+
+    const indices = options.map(({ value, label }) => value || label);
+
+    if (!indices.every(isActiveResponseFindingsIndex)) {
+      return `Active Response monitors can only use Wazuh findings indices (must start with "${ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX}").`;
+    }
+
+    if (indices.some((index) => index.includes('*'))) {
+      return 'Index patterns are not supported. Select a single findings index.';
+    }
+
+    // The available indices are unknown until the index field has loaded them, and an index that is
+    // not among them cannot be monitored.
+    if (availableIndices.length && indices.some((index) => !availableIndices.includes(index))) {
+      return 'Select one of the available findings indices.';
+    }
+  };
 
 export function isIndexPatternQueryValid(pattern, illegalCharacters) {
   if (!pattern || !pattern.length) {


### PR DESCRIPTION
## Description

In the **Create monitor** panel, typing an index in the index field and clicking outside it discarded the typed value: it was only applied when pressing <kbd>Enter</kbd>, and the field was left showing the typed text as invalid, so users could not tell whether their input had been taken.

The index combo box only turns typed text into a selection on blur while none of its options is active, and single selection pickers (Active Response and Per document monitors) keep an option active as soon as an index is selected. That is why the problem was reported in the Active Response flow, while Per query and Per bucket monitors, which allow several indices, are not affected.

Fixing only that would have widened an existing hole: a typed index bypasses the options list, which for Active Response monitors is restricted to the Wazuh findings indices. Active Response monitors are document level monitors, so they support neither an index outside the findings indices nor an index pattern (see wazuh/wazuh-dashboard-alerting#136, where the backend rejects patterns for document level monitors). The typed index is therefore always applied, and the selected value is validated so that the user is told why it cannot be used instead of believing it was accepted.

Closes https://github.com/wazuh/wazuh-dashboard-alerting/issues/133

Reported at wazuh/wazuh-dashboard-plugins#8809.

## Proposed Changes

- The index field applies the text left in its search input when it loses focus, for every monitor type, instead of relying on the combo box, which drops it while one of its options is active.
- The search input is reset once the typed index is applied, so the field renders the index that was applied instead of keeping the typed text marked as invalid.
- The index that is applied is the value that gets validated. The monitor form is created with `validateOnChange={false}` and Formik's `setFieldTouched` validates the value the field held before the handler ran, so the error of the replaced index used to stay on screen until the next interaction.
- Active Response monitors validate the selected index and report, with a specific message for each case, an index outside the Wazuh findings indices, an index pattern, and an index the field does not offer.
- The typed index is trimmed, so a trailing space no longer fails validation as an illegal character.
- Clearing the search input no longer empties the options list: the field falls back to its initial query, which keeps the findings indices listed for Active Response monitors.
- `FormikComboBox` accepts an optional `comboBoxRef`, needed to reset the combo box search input.

### Results and Evidence

https://github.com/user-attachments/assets/8282aba9-05c7-47a8-9b44-16291778d134

### How to test

1. Active Response: select a findings index from the list, click the field again, type another
   findings index and click outside. The typed index is applied without pressing Enter, no error.
   (This is the exact scenario of the issue.)
2. Active Response: type `wazuh-findings-v5-*` and click outside. The index is applied and the
   field reports "Index patterns are not supported. Select a single findings index.".
3. Active Response: type `wazuh-events-v5` and click outside. The field reports "Active Response
   monitors can only use Wazuh findings indices (must start with "wazuh-findings").".
4. Active Response: type a findings index that does not exist and click outside. The field reports
   "Select one of the available findings indices."

### Artifacts Affected

- Alerting plugin browser bundle (`public/` only). No server, packaging or dependency changes.

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

`public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js`:

- `applies the typed index on blur`: the typed index becomes the selected index, the error of the index it replaces is gone, and the search input no longer holds the typed text.
- `rejects indices Active Response monitors cannot run over`: an index outside the findings indices, an index pattern, and a findings index that is not offered are each applied and reported with their own message, while an offered findings index is accepted.
- `onBlur sets index to touched` was skipped because Enzyme's synthetic `blur` never reaches the combo box native `focusout` listener. It now drives a real event and is enabled again.

The render snapshot was refreshed for the new `comboBoxRef` input prop.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
