### PR TITLE
Improve repository bumper error handling

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -164,11 +164,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
+          echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -188,6 +191,17 @@ jobs:
             git commit -m "feat: revert ${{ github.ref_name }} references"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: 'Result: original bump pull request not found'
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: 'Result: no changes to commit'
+        if: >-
+          (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Push changes
         if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')


### PR DESCRIPTION
## Description

Closes #142

Today `.github/workflows/5_bumper_repository.yml` ends with the `failure` conclusion in two harmless situations that the release orchestration in `wazuh-qa-automation` now knows how to tell apart from a real failure (see [wazuh-qa-automation#8027](https://github.com/wazuh/wazuh-qa-automation/issues/8027)): a revert run whose original bump PR never existed (no-op bump), and a bump run that produces no changes. Since the orchestrator resolves the run outcome from step names, the workflow must end as `success` in both cases and report which one happened.

## Proposed Changes

- `Revert references (Revert)`: instead of `exit 1` when the original bump PR isn't found, emit `pr_found=false` / `has_changes=false` outputs and `exit 0`.
- Two new reporting steps, with names matched exactly (trimmed, case-insensitive) by the orchestrator:
  - `"Result: original bump pull request not found"` — runs only when the revert's original PR wasn't found.
  - `"Result: no changes to commit"` — runs when a bump produced no changes, or a revert found its original PR but had nothing left to revert.
- `Push changes`, `Create pull request`, and `Merge pull request` already shared a single guard condition (`bump_changes`/`revert_step` `has_changes`), so they're already skipped in both no-op cases without further changes.
- Normal bump and normal revert behavior is unchanged.

### Results and Evidence

<!-- Attach the links of the four validation runs described in the issue (revert with no original PR, bump with no changes, normal bump, normal revert) once run on the release branch. -->

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml` (CI workflow only — no plugin build artifacts affected).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — this is a GitHub Actions workflow; validated by running the four scenarios from the issue directly on the release branch (see Results and Evidence).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
