### PR TITLE
Improve the Active Response monitor UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 | Issue | Comment |
 | ----- | ------- |
 | [#13](https://github.com/wazuh/wazuh-dashboard-alerting/issues/13) | Added debounce to Document Level Query text inputs |
-| [#33](https://github.com/wazuh/wazuh-dashboard-alerting/pull/33) [#133](https://github.com/wazuh/wazuh-dashboard-alerting/issues/133) | Add "Active Response" monitor type |
+| [#33](https://github.com/wazuh/wazuh-dashboard-alerting/pull/33) [#133](https://github.com/wazuh/wazuh-dashboard-alerting/issues/133) [#147](https://github.com/wazuh/wazuh-dashboard-alerting/issues/147) | Add "Active Response" monitor type |
 
 ### Changed
 

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
@@ -194,7 +194,7 @@ const MonitorType = ({ values }) => (
           name="monitorTypeActiveResponse"
           inputProps={{
             id: 'activeResponseMonitorRadioCard',
-            label: 'Active Response',
+            label: 'Active Response monitor',
             checked: values.monitor_type === MONITOR_TYPE.ACTIVE_RESPONSE,
             value: MONITOR_TYPE.ACTIVE_RESPONSE,
             onChange: (e, field, form) => onChangeDefinition(e, form),

--- a/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
@@ -317,7 +317,7 @@ Array [
             class="euiCheckableCard__label"
             for="activeResponseMonitorRadioCard"
           >
-            Active Response
+            Active Response monitor
           </label>
           <div
             class="euiCheckableCard__children"

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequencies.test.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequencies.test.js
@@ -5,9 +5,10 @@
 
 import React from 'react';
 import { Formik } from 'formik';
-import { render } from 'enzyme';
+import { mount, render } from 'enzyme';
 
 import { FORMIK_INITIAL_VALUES } from '../../../containers/CreateMonitor/utils/constants';
+import { MONITOR_TYPE } from '../../../../../utils/constants';
 import Frequency from './Frequency';
 import Interval from './Interval';
 import Monthly from './Monthly';
@@ -47,5 +48,59 @@ describe('Frequencies', () => {
     );
 
     expect(render(component)).toMatchSnapshot();
+  });
+
+  // Wazuh: Active Response monitors only support a fixed interval of at most one minute
+  describe('Active Response monitor', () => {
+    const activeResponseValues = {
+      ...FORMIK_INITIAL_VALUES,
+      monitor_type: MONITOR_TYPE.ACTIVE_RESPONSE,
+    };
+
+    const mountWith = (values, Component) =>
+      mount(<Formik initialValues={values} render={() => <Component />} />);
+
+    test('offers the interval frequency only', () => {
+      const wrapper = mountWith(activeResponseValues, Frequency);
+      const { options } = wrapper.find('EuiCompressedSelect').first().props();
+
+      expect(options).toEqual([{ value: 'interval', text: 'By interval' }]);
+    });
+
+    test('keeps the frequency an existing monitor was saved with', () => {
+      const wrapper = mountWith(
+        { ...activeResponseValues, frequency: 'cronExpression' },
+        Frequency
+      );
+      const { options } = wrapper.find('EuiCompressedSelect').first().props();
+
+      expect(options.map(({ value }) => value)).toEqual(['interval', 'cronExpression']);
+    });
+
+    test('offers seconds and minutes, each capped at 60 seconds', () => {
+      const wrapper = mountWith(activeResponseValues, FrequencyPicker);
+
+      expect(wrapper.find('EuiCompressedSelect').first().props().options).toEqual([
+        { value: 'SECONDS', text: 'Second(s)' },
+        { value: 'MINUTES', text: 'Minute(s)' },
+      ]);
+      expect(wrapper.find('EuiCompressedFieldNumber').first().props().max).toBe(1);
+    });
+
+    test('raises the interval cap when the schedule is expressed in seconds', () => {
+      const wrapper = mountWith(
+        { ...activeResponseValues, period: { interval: 30, unit: 'SECONDS' } },
+        FrequencyPicker
+      );
+
+      expect(wrapper.find('EuiCompressedFieldNumber').first().props().max).toBe(60);
+    });
+
+    test('leaves the other monitor types alone', () => {
+      const wrapper = mountWith(FORMIK_INITIAL_VALUES, FrequencyPicker);
+
+      expect(wrapper.find('EuiCompressedSelect').first().props().options).toHaveLength(3);
+      expect(wrapper.find('EuiCompressedFieldNumber').first().props().max).toBeUndefined();
+    });
   });
 });

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequency.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequency.js
@@ -4,8 +4,14 @@
  */
 
 import React from 'react';
+import { connect } from 'formik'; // Wazuh
 import { FormikSelect } from '../../../../../components/FormControls';
 import { isInvalid, hasError } from '../../../../../utils/validate';
+// Wazuh
+import {
+  ACTIVE_RESPONSE_MAX_INTERVAL_SECONDS,
+  MONITOR_TYPE,
+} from '../../../../../utils/constants';
 
 const frequencies = [
   { value: 'interval', text: 'By interval' },
@@ -22,21 +28,42 @@ const flyoutFrequencies = [
   { value: 'monthly', text: 'Monthly' },
 ];
 
-const Frequency = ({ flyoutMode }) => (
+/*
+ * Wazuh: the indexer only accepts an interval schedule for an Active Response monitor, so the other
+ * frequencies are hidden. A monitor already saved with another one keeps its option, to not change
+ * the schedule silently.
+ */
+const getFrequencies = ({ flyoutMode, monitorType, frequency }) => {
+  const options = flyoutMode ? flyoutFrequencies : frequencies;
+  if (monitorType !== MONITOR_TYPE.ACTIVE_RESPONSE) return options;
+  return options.filter(({ value }) => value === 'interval' || value === frequency);
+};
+
+const Frequency = ({ flyoutMode, formik }) => (
   <FormikSelect
     name="frequency"
     formRow
     rowProps={{
       label: 'Frequency',
+      // Wazuh
+      helpText:
+        formik.values.monitor_type === MONITOR_TYPE.ACTIVE_RESPONSE
+          ? `Active Response monitors run on an interval of at most ${ACTIVE_RESPONSE_MAX_INTERVAL_SECONDS} seconds.`
+          : undefined,
       isInvalid,
       error: hasError,
     }}
     inputProps={{
-      options: flyoutMode ? flyoutFrequencies : frequencies,
+      // Wazuh
+      options: getFrequencies({
+        flyoutMode,
+        monitorType: formik.values.monitor_type,
+        frequency: formik.values.frequency,
+      }),
       isInvalid,
       'data-test-subj': 'frequency_field',
     }}
   />
 );
 
-export default Frequency;
+export default connect(Frequency); // Wazuh

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/FrequencyPicker.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/FrequencyPicker.js
@@ -21,9 +21,10 @@ const components = {
 };
 
 const FrequencyPicker = (props) => {
-  const type = props.formik.values.frequency;
-  const Component = components[type];
-  return <Component compressed />;
+  const { frequency, monitor_type: monitorType } = props.formik.values;
+  const Component = components[frequency];
+  // Wazuh: the interval limits depend on the monitor type
+  return <Component compressed monitorType={monitorType} />;
 };
 
 export default connect(FrequencyPicker);

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Interval.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Interval.js
@@ -4,15 +4,20 @@
  */
 
 import React from 'react';
+import { connect } from 'formik'; // Wazuh
 import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 
 import { FormikFieldNumber, FormikSelect } from '../../../../../components/FormControls';
 import {
   isInvalid,
   hasError,
+  validateActiveResponseInterval,
+  validateActiveResponseUnit,
   validatePositiveInteger,
   validateUnit,
 } from '../../../../../utils/validate';
+// Wazuh
+import { ACTIVE_RESPONSE_MAX_INTERVAL, MONITOR_TYPE } from '../../../../../utils/constants';
 
 export const unitOptions = [
   { value: 'MINUTES', text: 'Minute(s)' },
@@ -28,13 +33,27 @@ export const unitToLabel = unitOptions.reduce(
   {}
 );
 
-const Interval = () => (
+/*
+ * Wazuh: the indexer caps an Active Response monitor schedule at 60 seconds, so hours and days
+ * never apply and seconds become useful. The cap itself depends on the unit in use.
+ */
+const isActiveResponse = (monitorType) => monitorType === MONITOR_TYPE.ACTIVE_RESPONSE;
+const activeResponseUnitOptions = [
+  { value: 'SECONDS', text: 'Second(s)' },
+  ...unitOptions.filter(({ value }) => value === 'MINUTES'),
+];
+
+const Interval = ({ monitorType, formik }) => (
   <EuiFlexGroup alignItems="flexStart" gutterSize="m">
     <EuiFlexItem>
       <FormikFieldNumber
         name="period.interval"
         formRow
-        fieldProps={{ validate: validatePositiveInteger }}
+        fieldProps={{
+          validate: isActiveResponse(monitorType)
+            ? validateActiveResponseInterval(formik.values.period?.unit)
+            : validatePositiveInteger,
+        }}
         rowProps={{
           label: 'Run every',
           isInvalid,
@@ -43,6 +62,9 @@ const Interval = () => (
         inputProps={{
           icon: 'clock',
           min: 1,
+          max: isActiveResponse(monitorType)
+            ? ACTIVE_RESPONSE_MAX_INTERVAL[formik.values.period?.unit]
+            : undefined,
           'data-test-subj': 'interval_interval_field',
         }}
       />
@@ -51,14 +73,16 @@ const Interval = () => (
       <FormikSelect
         name="period.unit"
         formRow
-        fieldProps={{ validate: validateUnit }}
+        fieldProps={{
+          validate: isActiveResponse(monitorType) ? validateActiveResponseUnit : validateUnit,
+        }}
         rowProps={{
           hasEmptyLabelSpace: true,
           isInvalid,
           error: hasError,
         }}
         inputProps={{
-          options: unitOptions,
+          options: isActiveResponse(monitorType) ? activeResponseUnitOptions : unitOptions,
           'data-test-subj': 'interval_unit_field',
         }}
       />
@@ -66,4 +90,4 @@ const Interval = () => (
   </EuiFlexGroup>
 );
 
-export default Interval;
+export default connect(Interval); // Wazuh

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -27,6 +27,7 @@ import { FORMIK_INITIAL_VALUES, LOOKBACK_WINDOW_MAX_MINUTES } from './utils/cons
 import { formikToMonitor } from './utils/formikToMonitor';
 import { MONITOR_TYPE, SEARCH_TYPE } from '../../../../utils/constants';
 import { SubmitErrorHandler } from '../../../../utils/SubmitErrorHandler';
+import { createToastTracker } from '../../../../utils/toastTracker'; // Wazuh
 import MonitorDetails from '../MonitorDetails';
 import ConfigureTriggers from '../../../CreateTrigger/containers/ConfigureTriggers';
 import ConfigureTriggersPpl from '../../../CreateTrigger/containers/ConfigureTriggers/ConfigureTriggersPpl';
@@ -83,6 +84,9 @@ export default class CreateMonitor extends Component {
         triggerToEdit = triggerToFormik(_.get(monitorToEdit, 'triggers', []), monitorToEdit);
       }
     }
+
+    // Wazuh: remove the toasts this form raised, so they do not cover the next form's action bar
+    this.toastTracker = createToastTracker(props.notifications);
 
     this.state = {
       plugins: [],
@@ -184,7 +188,8 @@ export default class CreateMonitor extends Component {
   }
 
   onSubmit(values, formikBag) {
-    const { edit, history, updateMonitor, notifications, httpClient, monitorToEdit } = this.props;
+    const { edit, history, updateMonitor, httpClient, monitorToEdit } = this.props;
+    const { notifications } = this.toastTracker; // Wazuh
     const { triggerToEdit } = this.state;
 
     if (values.monitor_type === MONITOR_TYPE.PPL) {
@@ -222,6 +227,7 @@ export default class CreateMonitor extends Component {
 
   componentWillUnmount() {
     this.props.setFlyout(null);
+    this.toastTracker.removeAll(); // Wazuh
   }
 
   componentDidUpdate(prevProps) {
@@ -652,7 +658,7 @@ export default class CreateMonitor extends Component {
                   isSubmitting={isSubmitting}
                   isValid={isValid}
                   onSubmitError={() =>
-                    notifications.toasts.addDanger({
+                    this.toastTracker.notifications.toasts.addDanger({
                       title: `Failed to ${edit ? 'update' : 'create'} the monitor`,
                       text: 'Fix all highlighted error(s) before continuing.',
                     })

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
@@ -208,6 +208,8 @@ export const create = async ({
   } catch (err) {
     console.error(err);
     setSubmitting(false);
+    // Wazuh: a failed creation used to leave no trace in the UI
+    backendErrorNotification(notifications, 'create', 'monitor', err.message);
   }
 };
 
@@ -224,10 +226,13 @@ export const update = async ({ history, updateMonitor, notifications, monitor, f
       history.push(`/monitors/${id}?type=${isWorkflow ? 'workflow' : 'monitor'}`);
     } else {
       console.log('Failed to update:', resp);
+      // Wazuh: a failed update used to leave no trace in the UI
+      backendErrorNotification(notifications, 'update', 'monitor', resp.resp);
     }
   } catch (err) {
     console.error(err);
     setSubmitting(false);
+    backendErrorNotification(notifications, 'update', 'monitor', err.message);
   }
 };
 

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -18,7 +18,11 @@ import {
   validateMonitorIndex,
 } from '../../../../utils/validate';
 import { canAppendWildcard, createReasonableWait, getMatchedOptions } from './utils/helpers';
-import { ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN, MONITOR_TYPE } from '../../../../utils/constants';
+import {
+  ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN,
+  MONITOR_TYPE,
+  MONITOR_TYPE_LABEL,
+} from '../../../../utils/constants';
 import CrossClusterConfiguration from '../../components/CrossClusterConfigurations/containers';
 import {
   getDataSourceQueryObj,
@@ -340,11 +344,13 @@ class MonitorIndex extends React.Component {
         .filter((group) => group.options.length > 0);
     }
 
-    // Wazuh: document level monitors are rejected by the backend when the index is a
-    // pattern, so the help text must not advertise wildcards or date math for them.
+    // Wazuh: document level and Active Response monitors are rejected by the backend when the index
+    // is a pattern, so the help text must not advertise wildcards or date math for them.
     const indexHelpText = supportsIndexPatterns(this.props.monitorType)
       ? 'You can use a * as a wildcard or date math index resolution in your index pattern'
-      : 'Document level monitors do not support index patterns. Specify a concrete index name, without wildcards or date math index resolution.';
+      : `${_.upperFirst(
+          MONITOR_TYPE_LABEL[this.props.monitorType]
+        )} do not support index patterns. Specify a concrete index name, without wildcards or date math index resolution.`;
 
     // Wazuh: a typed index bypasses the options list, so Active Response monitors validate that the
     // selected value is an existing findings index. The rest of the monitor types only need the

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -176,16 +176,16 @@ describe('MonitorIndex', () => {
       );
     });
 
-    test.each([MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.ACTIVE_RESPONSE])(
-      'states the restriction for %s',
-      (monitorType) => {
-        const wrapper = getMountWrapper({ monitorType });
+    test.each([
+      [MONITOR_TYPE.DOC_LEVEL, 'Document level monitors'],
+      [MONITOR_TYPE.ACTIVE_RESPONSE, 'Active Response monitors'],
+    ])('states the restriction for %s', (monitorType, monitorTypeLabel) => {
+      const wrapper = getMountWrapper({ monitorType });
 
-        expect(wrapper.find('.euiFormHelpText').text()).toBe(
-          'Document level monitors do not support index patterns. Specify a concrete index name, without wildcards or date math index resolution.'
-        );
-      }
-    );
+      expect(wrapper.find('.euiFormHelpText').text()).toBe(
+        `${monitorTypeLabel} do not support index patterns. Specify a concrete index name, without wildcards or date math index resolution.`
+      );
+    });
   });
 
   test('sets option when calling onCreateOption', async () => {

--- a/public/pages/CreateTrigger/components/Action/EnhancedAction.js
+++ b/public/pages/CreateTrigger/components/Action/EnhancedAction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright OpenSearch Contributors
+ * Copyright Wazuh Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,8 +7,9 @@ import React, { useState, useMemo } from 'react';
 import _ from 'lodash';
 import {
   EuiAccordion,
+  EuiBadge,
+  EuiCompressedFormRow,
   EuiSmallButton,
-  EuiButton,
   EuiHorizontalRule,
   EuiPanel,
   EuiSpacer,
@@ -38,6 +39,70 @@ import MinimalAccordion from '../../../../components/FeatureAnywhereContextMenu/
 import { getActionTypeFromAction, getManageChannelsUrl } from '../../../../utils/helpers';
 import { MANAGED_CHANNEL_CATEGORY } from '../../../../utils/constants';
 import { isManagedChannelType } from '../../../../services/utils/helper';
+import {
+  ACTION_FIELD_WIDTH,
+  ACTIVE_RESPONSE_LOCATION,
+  ACTIVE_RESPONSE_LOCATION_LABEL,
+  ACTIVE_RESPONSE_TYPE_LABEL,
+} from './utils/constants';
+
+/*
+ * EuiComboBox renders its list with a fixed row height, so anything taller than rowHeight
+ * is cut off by the next row. The active response row is built from these fixed pieces and its
+ * height is derived from them. The badges are laid out with flex, not as inline blocks, so they
+ * do not leak below the text baseline.
+ */
+const OPTION_NAME_HEIGHT = 20;
+const OPTION_BADGES_HEIGHT = 20; // an EuiBadge is 18px of line height plus its 1px borders
+const OPTION_LINE_GAP = 6;
+const OPTION_VERTICAL_SPACE = 9; // the row's 4px + 4px padding and its 1px bottom border
+const OPTION_BREATHING_ROOM = 6;
+const ACTIVE_RESPONSE_ROW_HEIGHT =
+  OPTION_NAME_HEIGHT +
+  OPTION_LINE_GAP +
+  OPTION_BADGES_HEIGHT +
+  OPTION_VERTICAL_SPACE +
+  OPTION_BREATHING_ROOM;
+const CHANNEL_ROW_HEIGHT = 46;
+
+// An active response is only safe to arm once its target and mute state are visible
+const renderActiveResponseOption = ({ label, isEnabled, activeResponse = {} }) => {
+  const { type, location } = activeResponse;
+  const locationLabel = ACTIVE_RESPONSE_LOCATION_LABEL[location];
+  const typeLabel = ACTIVE_RESPONSE_TYPE_LABEL[type];
+  const badges = [
+    locationLabel && {
+      label: locationLabel,
+      color: location === ACTIVE_RESPONSE_LOCATION.ALL ? 'warning' : 'default',
+    },
+    typeLabel && { label: typeLabel, color: 'default' },
+    isEnabled === false && { label: 'Muted · will not run', color: 'danger' },
+  ].filter(Boolean);
+
+  return (
+    <div style={{ width: '100%', overflow: 'hidden' }}>
+      <div className="eui-textTruncate" style={{ lineHeight: `${OPTION_NAME_HEIGHT}px` }}>
+        {label}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+          height: `${OPTION_BADGES_HEIGHT}px`,
+          marginTop: `${OPTION_LINE_GAP}px`,
+          overflow: 'hidden',
+        }}
+      >
+        {badges.map(({ label: badgeLabel, color }) => (
+          <EuiBadge key={badgeLabel} color={color} style={{ flex: '0 0 auto' }}>
+            {badgeLabel}
+          </EuiBadge>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 const Action = ({
   action,
@@ -59,10 +124,9 @@ const Action = ({
 }) => {
   const [backupValues, setBackupValues] = useState();
   const [isConfigureOpen, setIsConfigureOpen] = useState(false);
-  const ManageButton = useMemo(
-    () => (flyoutMode ? EuiSmallButtonEmpty : EuiSmallButton),
-    [flyoutMode]
-  );
+  const ManageButton = useMemo(() => (flyoutMode ? EuiSmallButtonEmpty : EuiSmallButton), [
+    flyoutMode,
+  ]);
   const Accordion = useMemo(() => (flyoutMode ? MinimalAccordion : EuiAccordion), [flyoutMode]);
   const [loadingDestinations, setLoadingDestinations] = useState(false);
   const selectedDestination = flattenedDestinations.filter(
@@ -71,10 +135,12 @@ const Action = ({
   const type = _.get(selectedDestination, '0.type', DEFAULT_ACTION_TYPE);
 
   const actionType = getActionTypeFromAction(action);
+  const isActiveResponse = actionType === MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE;
   const { name } = action;
   let ActionComponent;
   const actionLabelNotification = 'Notification';
-  const actionLabelActiveResponse = 'Active Response';
+  const actionLabelActiveResponse = 'Active response';
+  const actionLabelText = isActiveResponse ? actionLabelActiveResponse : actionLabelNotification;
 
   if (actionType === MANAGED_CHANNEL_CATEGORY.NOTIFICATION) {
     if (type === 'webhook') {
@@ -82,7 +148,7 @@ const Action = ({
     } else {
       ActionComponent = defaultNotificationActionMessageComponent;
     }
-  } else if (actionType === MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE) {
+  } else if (isActiveResponse) {
     // Wazuh: active response action type
     ActionComponent = activeResponseActionMessageComponent;
   }
@@ -139,28 +205,34 @@ const Action = ({
       placeHolderText = 'Select channel to notify';
       dropdownLabelText = 'Channel';
       options = destinations.filter((dest) => !isManagedChannelType(dest.key));
-    } else if (actionType === MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE) {
+    } else if (isActiveResponse) {
       placeHolderText = 'Select active response to execute';
       dropdownLabelText = 'Active response';
-      options = destinations.filter(
-        (dest) => dest.key === MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE
-      );
+      // The list holds nothing but active responses, so its group heading would only add an
+      // empty row as tall as a real option
+      options = destinations
+        .filter((dest) => dest.key === MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE)
+        .flatMap((group) => group.options);
     }
     return (
       <div>
-        <EuiFlexGroup wrap>
-          <EuiFlexItem style={{ maxWidth: 400 }}>
+        <EuiFlexGroup wrap alignItems="flexStart" gutterSize="s">
+          <EuiFlexItem grow={false} style={{ width: ACTION_FIELD_WIDTH }}>
             <FormikComboBox
               name={`${fieldPath}actions.${index}.destination_id`}
               formRow
-              fieldProps={{ validate: validateDestination(flattenedDestinations, flyoutMode) }}
+              fieldProps={{
+                validate: validateDestination(flattenedDestinations, flyoutMode, actionType),
+              }}
               rowProps={{
                 label: dropdownLabelText,
+                fullWidth: true,
                 isInvalid,
                 error: hasError,
               }}
               inputProps={{
                 placeholder: placeHolderText,
+                fullWidth: true,
                 options: options,
                 selectedOptions: selectedDestination,
                 isDisabled: !hasNotificationPlugin,
@@ -177,38 +249,38 @@ const Action = ({
                 },
                 onFocus: refreshDestinations,
                 singleSelection: { asPlainText: true },
-                isClearable: false,
+                isClearable: true,
                 'data-test-subj': 'channelComboBox',
-                renderOption: (option) => (
-                  <div style={{ lineHeight: '1' }}>
-                    <EuiText size="s">
-                      {option.label}
-                    </EuiText>
-                    {option.description && (
-                      <EuiText
-                        size="xs"
-                        color="subdued"
-                      >
-                        {option.description}
-                      </EuiText>
-                    )}
-                  </div>
-                ),
-                rowHeight: 46,
+                renderOption: (option) =>
+                  isActiveResponse ? (
+                    renderActiveResponseOption(option)
+                  ) : (
+                    <div style={{ lineHeight: '1' }}>
+                      <EuiText size="s">{option.label}</EuiText>
+                      {option.description && (
+                        <EuiText size="xs" color="subdued">
+                          {option.description}
+                        </EuiText>
+                      )}
+                    </div>
+                  ),
+                rowHeight: isActiveResponse ? ACTIVE_RESPONSE_ROW_HEIGHT : CHANNEL_ROW_HEIGHT,
                 isLoading: !flyoutMode && loadingDestinations,
               }}
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiSpacer size="l" />
-            <ManageButton
-              disabled={!hasNotificationPlugin}
-              iconType="popout"
-              iconSide="right"
-              onClick={() => window.open(getManageChannelsUrl(actionType))}
-            >
-              {actionType === 'notification' ? 'Manage channels' : 'Manage active responses'}
-            </ManageButton>
+            {/* The empty label keeps the button level with the input, whatever is below it */}
+            <EuiCompressedFormRow hasEmptyLabelSpace>
+              <ManageButton
+                disabled={!hasNotificationPlugin}
+                iconType="popout"
+                iconSide="right"
+                onClick={() => window.open(getManageChannelsUrl(actionType))}
+              >
+                {isActiveResponse ? 'Manage active responses' : 'Manage channels'}
+              </ManageButton>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer size="m" />
@@ -234,7 +306,7 @@ const Action = ({
                   <EuiSmallButtonIcon
                     iconType="trash"
                     color="text"
-                    aria-label={`Delete Notification`}
+                    aria-label={`Delete ${actionLabelText.toLowerCase()} action`}
                     onClick={onDelete}
                   />
                 ),
@@ -246,19 +318,19 @@ const Action = ({
                 className: 'accordion-action',
                 buttonContent: (
                   <EuiText>
-                    {actionType === 'notification'
-                      ? !_.get(selectedDestination, '0.type', undefined)
-                        ? actionLabelNotification
-                        : `${actionLabelNotification}: ${name}`
-                      : !_.get(selectedDestination, '0.type', undefined)
-                      ? actionLabelActiveResponse
-                      : `${actionLabelActiveResponse}: ${name}`}
+                    {!_.get(selectedDestination, '0.type', undefined)
+                      ? actionLabelText
+                      : `${actionLabelText}: ${name}`}
                   </EuiText>
                 ),
                 extraAction: (
-                  <EuiButton color={'danger'} onClick={onDelete} size={'s'}>
-                    Remove action
-                  </EuiButton>
+                  // Matches the flyout variant instead of a full-size danger button
+                  <EuiSmallButtonIcon
+                    iconType="trash"
+                    color="text"
+                    aria-label={`Remove ${actionLabelText.toLowerCase()} action`}
+                    onClick={onDelete}
+                  />
                 ),
                 paddingSize: 's',
               })}
@@ -279,7 +351,6 @@ const Action = ({
                   }}
                   rowProps={{
                     label: 'Action name',
-                    helpText: 'Names can only contain letters, numbers, and special characters',
                     isInvalid,
                     error: hasError,
                   }}
@@ -297,6 +368,7 @@ const Action = ({
               <ActionComponent
                 action={action}
                 context={context}
+                selectedDestination={selectedDestination[0]}
                 index={index}
                 sendTestMessage={sendTestMessage}
                 setFlyout={setFlyout}
@@ -304,7 +376,7 @@ const Action = ({
                 values={values}
               />
             )}
-            {flyoutMode && !isInitialLoading && actionType === 'notification' && (
+            {flyoutMode && !isInitialLoading && !isActiveResponse && (
               <>
                 <EuiSmallButtonEmpty iconType="pencil" iconSide="left" onClick={onConfigureOpen}>
                   Configure

--- a/public/pages/CreateTrigger/components/Action/EnhancedAction.test.js
+++ b/public/pages/CreateTrigger/components/Action/EnhancedAction.test.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+
+import EnhancedAction from './EnhancedAction';
+import { MANAGED_CHANNEL_CATEGORY } from '../../../../utils/constants';
+import { ACTIVE_RESPONSE_LOCATION, ACTIVE_RESPONSE_TYPE } from './utils/constants';
+
+jest.mock('../../../../services', () => ({
+  ...jest.requireActual('../../../../services'),
+  getUseUpdatedUx: () => false,
+}));
+
+const activeResponse = (overrides = {}) => ({
+  label: 'Isolate-compromised-host',
+  value: 'config-id',
+  type: MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE,
+  isEnabled: true,
+  activeResponse: {
+    executable: 'host-deny',
+    extra_args: '',
+    type: ACTIVE_RESPONSE_TYPE.STATELESS,
+    location: ACTIVE_RESPONSE_LOCATION.LOCAL,
+  },
+  ...overrides,
+});
+
+const getWrapper = (option) => {
+  const destinations = [
+    {
+      key: MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE,
+      label: 'Active responses',
+      options: [{ key: option.value, ...option }],
+    },
+  ];
+
+  return mount(
+    <Formik initialValues={{}}>
+      {() => (
+        <EnhancedAction
+          action={{ id: 'activeResponse1', name: 'Isolate-action' }}
+          arrayHelpers={{}}
+          context={{ ctx: { monitor: {}, trigger: {} } }}
+          destinations={destinations}
+          flattenedDestinations={[option]}
+          index={0}
+          onDelete={() => {}}
+          sendTestMessage={() => {}}
+          setFlyout={() => {}}
+          fieldPath=""
+          values={{}}
+          hasNotificationPlugin
+          loadDestinations={() => {}}
+        />
+      )}
+    </Formik>
+  );
+};
+
+const getRenderedOption = (wrapper, option) => {
+  const { renderOption } = wrapper.find('EuiCompressedComboBox').first().props();
+  return mount(<div>{renderOption(option)}</div>);
+};
+
+describe('EnhancedAction', () => {
+  test('shows the location and type of every active response', () => {
+    const option = activeResponse();
+    const text = getRenderedOption(getWrapper(option), option).text();
+
+    expect(text).toContain('Isolate-compromised-host');
+    expect(text).toContain('Local');
+    expect(text).toContain('Stateless');
+    expect(text).not.toContain('Muted');
+  });
+
+  test('badges a fleet-wide active response with the warning color', () => {
+    const option = activeResponse({
+      activeResponse: {
+        ...activeResponse().activeResponse,
+        location: ACTIVE_RESPONSE_LOCATION.ALL,
+      },
+    });
+    const rendered = getRenderedOption(getWrapper(option), option);
+
+    expect(rendered.text()).toContain('All agents');
+    expect(rendered.find('EuiBadge').first().props().color).toBe('warning');
+  });
+
+  test('badges a muted active response as not running', () => {
+    const option = activeResponse({ isEnabled: false });
+
+    expect(getRenderedOption(getWrapper(option), option).text()).toContain('Muted · will not run');
+  });
+
+  test('offers active responses without a group heading row', () => {
+    const option = activeResponse();
+    const { options } = getWrapper(option).find('EuiCompressedComboBox').first().props();
+
+    expect(options).toEqual([{ key: option.value, ...option }]);
+  });
+
+  test('lets the selected active response be cleared', () => {
+    const wrapper = getWrapper(activeResponse());
+
+    expect(wrapper.find('EuiCompressedComboBox').first().props().isClearable).toBe(true);
+  });
+});

--- a/public/pages/CreateTrigger/components/Action/actions/ActiveResponseSummary.js
+++ b/public/pages/CreateTrigger/components/Action/actions/ActiveResponseSummary.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiDescriptionList, EuiLink, EuiPanel, EuiSpacer } from '@elastic/eui';
+import { MANAGED_CHANNEL_CATEGORY } from '../../../../../utils/constants';
+import { getManageChannelsUrl } from '../../../../../utils/helpers';
+import {
+  ACTION_FIELD_WIDTH,
+  ACTIVE_RESPONSE_LOCATION,
+  ACTIVE_RESPONSE_LOCATION_LABEL,
+  ACTIVE_RESPONSE_SUMMARY_TITLE_WIDTH,
+  ACTIVE_RESPONSE_TYPE,
+  ACTIVE_RESPONSE_TYPE_LABEL,
+} from '../utils/constants';
+
+export const getActiveResponseTypeDescription = ({ type, stateful_timeout: statefulTimeout }) => {
+  const label = ACTIVE_RESPONSE_TYPE_LABEL[type];
+  if (!label) return '-';
+  if (type !== ACTIVE_RESPONSE_TYPE.STATEFUL || !statefulTimeout) return label;
+  return `${label} · reverted after ${statefulTimeout} seconds`;
+};
+
+export const getActiveResponseLocationDescription = ({ location, agent_id: agentId }) => {
+  const label = ACTIVE_RESPONSE_LOCATION_LABEL[location];
+  if (!label) return '-';
+  if (location !== ACTIVE_RESPONSE_LOCATION.DEFINED_AGENT || !agentId) return label;
+  return `${label} · ${agentId}`;
+};
+
+const ActiveResponseSummary = ({ selectedDestination }) => {
+  const activeResponse = selectedDestination?.activeResponse;
+  if (!activeResponse) return null;
+
+  const { description } = selectedDestination;
+  const { executable, extra_args: extraArgs, location } = activeResponse;
+  const isMuted = selectedDestination.isEnabled === false;
+  const targetsEveryAgent = location === ACTIVE_RESPONSE_LOCATION.ALL;
+
+  return (
+    <div style={{ maxWidth: ACTION_FIELD_WIDTH }}>
+      {targetsEveryAgent && (
+        <>
+          <EuiCallOut
+            title="Runs on every agent in the environment"
+            color="warning"
+            iconType="alert"
+            size="s"
+          >
+            <p>Confirm the monitor query is narrow enough before saving.</p>
+          </EuiCallOut>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      {isMuted && (
+        <>
+          <EuiCallOut title="This response is muted" color="warning" iconType="alert" size="s">
+            <p>
+              It will be saved to the trigger but will not execute until it is unmuted.{' '}
+              <EuiLink
+                href={getManageChannelsUrl(MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE)}
+                target="_blank"
+                external
+              >
+                Unmute in Active responses
+              </EuiLink>
+            </p>
+          </EuiCallOut>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      <EuiPanel color="subdued" paddingSize="m">
+        <EuiDescriptionList
+          compressed
+          type="responsiveColumn"
+          titleProps={{ style: { width: ACTIVE_RESPONSE_SUMMARY_TITLE_WIDTH } }}
+          listItems={[
+            ...(description ? [{ title: 'Description', description }] : []),
+            {
+              title: 'Executable',
+              description: [executable, extraArgs].filter(Boolean).join(' ') || '-',
+            },
+            { title: 'Type', description: getActiveResponseTypeDescription(activeResponse) },
+            {
+              title: 'Location',
+              description: getActiveResponseLocationDescription(activeResponse),
+            },
+          ]}
+        />
+      </EuiPanel>
+    </div>
+  );
+};
+
+export default ActiveResponseSummary;

--- a/public/pages/CreateTrigger/components/Action/actions/ActiveResponseSummary.test.js
+++ b/public/pages/CreateTrigger/components/Action/actions/ActiveResponseSummary.test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ActiveResponseSummary from './ActiveResponseSummary';
+import { ACTIVE_RESPONSE_LOCATION, ACTIVE_RESPONSE_TYPE } from '../utils/constants';
+
+jest.mock('../../../../../services', () => ({
+  ...jest.requireActual('../../../../../services'),
+  getUseUpdatedUx: () => false,
+}));
+
+const localResponse = {
+  isEnabled: true,
+  activeResponse: {
+    executable: 'block-ip',
+    extra_args: '--timeout 30',
+    type: ACTIVE_RESPONSE_TYPE.STATEFUL,
+    stateful_timeout: 30,
+    location: ACTIVE_RESPONSE_LOCATION.LOCAL,
+  },
+};
+
+const getText = (selectedDestination) =>
+  mount(<ActiveResponseSummary selectedDestination={selectedDestination} />).text();
+
+describe('ActiveResponseSummary', () => {
+  test('renders nothing until an active response is selected', () => {
+    expect(mount(<ActiveResponseSummary />).isEmptyRender()).toBe(true);
+    expect(mount(<ActiveResponseSummary selectedDestination={{}} />).isEmptyRender()).toBe(true);
+  });
+
+  test('summarizes the executable, type and location', () => {
+    const text = getText(localResponse);
+
+    expect(text).toContain('block-ip --timeout 30');
+    expect(text).toContain('Stateful · reverted after 30 seconds');
+    expect(text).toContain('Local');
+  });
+
+  test('names the agent when the response targets a defined agent', () => {
+    const text = getText({
+      ...localResponse,
+      activeResponse: {
+        ...localResponse.activeResponse,
+        location: ACTIVE_RESPONSE_LOCATION.DEFINED_AGENT,
+        agent_id: '003',
+      },
+    });
+
+    expect(text).toContain('Defined agent · 003');
+  });
+
+  test('warns when the response runs on every agent', () => {
+    const text = getText({
+      ...localResponse,
+      activeResponse: { ...localResponse.activeResponse, location: ACTIVE_RESPONSE_LOCATION.ALL },
+    });
+
+    expect(text).toContain('Runs on every agent in the environment');
+  });
+
+  test('warns when the response is muted', () => {
+    const wrapper = mount(
+      <ActiveResponseSummary selectedDestination={{ ...localResponse, isEnabled: false }} />
+    );
+
+    expect(wrapper.text()).toContain('This response is muted');
+    expect(wrapper.find('a').first().props().href).toContain('active-responses');
+  });
+
+  test('does not warn when the response is local and enabled', () => {
+    const text = getText(localResponse);
+
+    expect(text).not.toContain('Runs on every agent in the environment');
+    expect(text).not.toContain('This response is muted');
+  });
+});

--- a/public/pages/CreateTrigger/components/Action/utils/constants.js
+++ b/public/pages/CreateTrigger/components/Action/utils/constants.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Every field in the action panel, and the summary of the selected active response, share one
+ * measure so the panel reads as a single column. 400px is the width OUI gives a form control.
+ */
+export const ACTION_FIELD_WIDTH = 400;
+export const ACTIVE_RESPONSE_SUMMARY_TITLE_WIDTH = '35%';
+
+// The configuration of an active response, as the notifications plugin stores it
+export const ACTIVE_RESPONSE_LOCATION = Object.freeze({
+  ALL: 'all',
+  DEFINED_AGENT: 'defined-agent',
+  LOCAL: 'local',
+});
+
+export const ACTIVE_RESPONSE_LOCATION_LABEL = Object.freeze({
+  [ACTIVE_RESPONSE_LOCATION.ALL]: 'All agents',
+  [ACTIVE_RESPONSE_LOCATION.DEFINED_AGENT]: 'Defined agent',
+  [ACTIVE_RESPONSE_LOCATION.LOCAL]: 'Local',
+});
+
+export const ACTIVE_RESPONSE_TYPE = Object.freeze({
+  STATELESS: 'stateless',
+  STATEFUL: 'stateful',
+});
+
+export const ACTIVE_RESPONSE_TYPE_LABEL = Object.freeze({
+  [ACTIVE_RESPONSE_TYPE.STATELESS]: 'Stateless',
+  [ACTIVE_RESPONSE_TYPE.STATEFUL]: 'Stateful',
+});

--- a/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
@@ -29,7 +29,7 @@ const AddActionButton = ({
   const buttonActiveResponseText = 'Add active response';
   // Telling someone and changing the state of a machine are different decisions
   const notificationHelpText = 'Send an alert to a channel.';
-  const activeResponseHelpText = 'Run a command on the affected agent.';
+  const activeResponseHelpText = 'Run a command on one or more agents.';
   const notificationIcon = 'bell';
   const activeResponseIcon = 'console';
   const monitorType = _.get(arrayHelpers, 'form.values.monitor_type', MONITOR_TYPE.QUERY_LEVEL);

--- a/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
@@ -5,7 +5,14 @@
 
 import React from 'react';
 import _ from 'lodash';
-import { EuiButton, EuiSmallButtonEmpty, EuiPanel } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSmallButtonEmpty,
+  EuiPanel,
+  EuiText,
+} from '@elastic/eui';
 import { getInitialActionValues } from './enhanced-utils';
 import { MANAGED_CHANNEL_CATEGORY, MONITOR_TYPE } from '../../../../utils/constants';
 import './styles.scss';
@@ -20,6 +27,11 @@ const AddActionButton = ({
 }) => {
   const buttonNotificationText = 'Add notification';
   const buttonActiveResponseText = 'Add active response';
+  // Telling someone and changing the state of a machine are different decisions
+  const notificationHelpText = 'Send an alert to a channel.';
+  const activeResponseHelpText = 'Run a command on the affected agent.';
+  const notificationIcon = 'bell';
+  const activeResponseIcon = 'bolt';
   const monitorType = _.get(arrayHelpers, 'form.values.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
   const onClickNotification = () => {
     const actions = _.get(values, `${fieldPath}actions`, []);
@@ -55,7 +67,7 @@ const AddActionButton = ({
     <EuiPanel paddingSize="none">
       <EuiSmallButtonEmpty
         onClick={onClickNotification}
-        iconType="plusInCircle"
+        iconType={notificationIcon}
         className="add-action-button__flyout-button"
       >
         {buttonNotificationText}
@@ -63,7 +75,7 @@ const AddActionButton = ({
       {monitorType === MONITOR_TYPE.ACTIVE_RESPONSE && (
         <EuiSmallButtonEmpty
           onClick={onClickActiveResponse}
-          iconType="plusInCircle"
+          iconType={activeResponseIcon}
           className="add-action-button__flyout-button"
         >
           {buttonActiveResponseText}
@@ -71,26 +83,40 @@ const AddActionButton = ({
       )}
     </EuiPanel>
   ) : (
-    <>
-      <div
-        style={{
-          display: 'flex',
-          gap: '8px',
-          margin: '0 auto',
-          maxWidth: '500px',
-          justifyContent: 'center',
-        }}
-      >
-        <EuiButton fill={false} size={'s'} onClick={onClickNotification}>
+    <EuiFlexGroup
+      gutterSize="m"
+      justifyContent="center"
+      style={{ margin: '0 auto', maxWidth: '500px' }}
+    >
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          fill={false}
+          size={'s'}
+          iconType={notificationIcon}
+          onClick={onClickNotification}
+        >
           {buttonNotificationText}
         </EuiButton>
-        {monitorType === MONITOR_TYPE.ACTIVE_RESPONSE && (
-          <EuiButton fill={false} size={'s'} onClick={onClickActiveResponse}>
+        <EuiText size="xs" color="subdued" textAlign="center">
+          {notificationHelpText}
+        </EuiText>
+      </EuiFlexItem>
+      {monitorType === MONITOR_TYPE.ACTIVE_RESPONSE && (
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            fill={false}
+            size={'s'}
+            iconType={activeResponseIcon}
+            onClick={onClickActiveResponse}
+          >
             {buttonActiveResponseText}
           </EuiButton>
-        )}
-      </div>
-    </>
+          <EuiText size="xs" color="subdued" textAlign="center">
+            {activeResponseHelpText}
+          </EuiText>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
   );
 };
 

--- a/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/EnhancedAddActionButton.js
@@ -31,7 +31,7 @@ const AddActionButton = ({
   const notificationHelpText = 'Send an alert to a channel.';
   const activeResponseHelpText = 'Run a command on the affected agent.';
   const notificationIcon = 'bell';
-  const activeResponseIcon = 'bolt';
+  const activeResponseIcon = 'console';
   const monitorType = _.get(arrayHelpers, 'form.values.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
   const onClickNotification = () => {
     const actions = _.get(values, `${fieldPath}actions`, []);

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -158,6 +158,7 @@ class ConfigureActions extends React.Component {
 
     // Wazuh
     let indexActiveResponse = 0;
+    let activeResponses = [];
     const getActiveResponsesChannels = async () => {
       const getChannelsQuery = {
         from_index: indexActiveResponse,
@@ -169,16 +170,19 @@ class ConfigureActions extends React.Component {
 
       const channelsResponse = await this.props.notificationService.getChannels(getChannelsQuery);
 
-      channels = channels.concat(
+      activeResponses = activeResponses.concat(
         channelsResponse.items.map((channel) => ({
-          label: `[Active response] ${channel.name}`,
+          label: channel.name,
           value: channel.config_id,
           type: channel.config_type,
           description: channel.description,
+          // Wazuh: the trigger action needs the mute state and the configuration to warn about them
+          isEnabled: channel.is_enabled,
+          activeResponse: channel.active_response,
         }))
       );
 
-      if (channelsResponse.total && channels.length < channelsResponse.total) {
+      if (channelsResponse.total && activeResponses.length < channelsResponse.total) {
         indexActiveResponse += MAX_CHANNELS_RESULT_SIZE;
         await getActiveResponsesChannels();
       }
@@ -190,7 +194,7 @@ class ConfigureActions extends React.Component {
       await getActiveResponsesChannels();
     }
 
-    return channels;
+    return channels.concat(activeResponses);
   };
 
   loadDestinations = async (searchText = '') => {

--- a/public/pages/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/utils/constants.js
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import Message from '../components/Action/actions';
+// Wazuh
+import ActiveResponseSummary from '../components/Action/actions/ActiveResponseSummary';
 
 export const DEFAULT_MESSAGE_SOURCE = {
   BUCKET_LEVEL_MONITOR: `
@@ -82,4 +84,4 @@ export const webhookNotificationActionMessageComponent = (props) => (
 export const defaultNotificationActionMessageComponent = (props) => <Message {...props} />;
 
 // Wazuh
-export const activeResponseActionMessageComponent = () => null;
+export const activeResponseActionMessageComponent = (props) => <ActiveResponseSummary {...props} />;

--- a/public/pages/CreateTrigger/utils/helper.js
+++ b/public/pages/CreateTrigger/utils/helper.js
@@ -5,7 +5,7 @@
 
 import _ from 'lodash';
 import { DESTINATION_TYPE } from '../../Destinations/utils/constants';
-import { BACKEND_CHANNEL_TYPE, MONITOR_TYPE } from '../../../utils/constants';
+import { BACKEND_CHANNEL_TYPE, CHANNEL_TYPE, MONITOR_TYPE } from '../../../utils/constants';
 import { FORMIK_INITIAL_VALUES } from '../../CreateMonitor/containers/CreateMonitor/utils/constants';
 import {
   API_TYPES,
@@ -27,7 +27,7 @@ export const getChannelOptions = (channels) => {
     if (!channelMap[channel.type]) {
       channelMap[channel.type] = {
         key: channel.type,
-        label: channel.type,
+        label: CHANNEL_TYPE[channel.type] || channel.type, // Wazuh: not the raw backend key
         options: []
       };
     }

--- a/public/pages/CreateTrigger/utils/helper.test.js
+++ b/public/pages/CreateTrigger/utils/helper.test.js
@@ -4,8 +4,8 @@
  */
 
 import _ from 'lodash';
-import { getDefaultScript, getTriggerContext, getTimeZone } from './helper';
-import { MONITOR_TYPE } from '../../../utils/constants';
+import { getChannelOptions, getDefaultScript, getTriggerContext, getTimeZone } from './helper';
+import { BACKEND_CHANNEL_TYPE, CHANNEL_TYPE, MONITOR_TYPE } from '../../../utils/constants';
 import {
   FORMIK_INITIAL_DOC_LEVEL_SCRIPT,
   FORMIK_INITIAL_TRIGGER_VALUES,
@@ -18,6 +18,30 @@ import moment from 'moment-timezone';
 import { formikToTrigger } from '../containers/CreateTrigger/utils/formikToTrigger';
 
 describe('CreateTrigger/utils/helper', () => {
+  // Wazuh: the group heading used to render the raw backend key
+  describe('getChannelOptions', () => {
+    test('names each group after its channel type', () => {
+      const channels = [
+        { label: 'Block-IP', value: 'ar-1', type: BACKEND_CHANNEL_TYPE.ACTIVE_RESPONSE },
+        { label: '[Channel] Ops', value: 'ch-1', type: BACKEND_CHANNEL_TYPE.SLACK },
+      ];
+
+      expect(getChannelOptions(channels).map(({ key, label }) => ({ key, label }))).toEqual([
+        {
+          key: BACKEND_CHANNEL_TYPE.ACTIVE_RESPONSE,
+          label: CHANNEL_TYPE[BACKEND_CHANNEL_TYPE.ACTIVE_RESPONSE],
+        },
+        {
+          key: BACKEND_CHANNEL_TYPE.SLACK,
+          label: CHANNEL_TYPE[BACKEND_CHANNEL_TYPE.SLACK],
+        },
+      ]);
+    });
+
+    test('falls back to the type of an unknown channel', () => {
+      expect(getChannelOptions([{ value: 'x', type: 'brand_new' }])[0].label).toBe('brand_new');
+    });
+  });
   describe('getDefaultScript', () => {
     test('when monitor_type is undefined', () => {
       const monitorValues = undefined;

--- a/public/pages/Monitors/components/MonitorControls/MonitorControls.js
+++ b/public/pages/Monitors/components/MonitorControls/MonitorControls.js
@@ -11,6 +11,9 @@ import {
   EuiPagination,
   EuiCompressedSelect,
 } from '@elastic/eui';
+// Wazuh
+import { DEFAULT_QUERY_PARAMS } from '../../containers/Monitors/utils/constants';
+import { getMonitorTypeOptions } from '../../containers/Monitors/utils/activeResponses';
 
 const MONITOR_STATES = {
   ALL: 'all',
@@ -24,13 +27,21 @@ const states = [
   { value: MONITOR_STATES.DISABLED, text: 'Disabled' },
 ];
 
+// Wazuh: with a Type column present, a type filter makes each monitor type findable in a long list
+const monitorTypes = [
+  { value: DEFAULT_QUERY_PARAMS.monitorType, text: 'All types' },
+  ...getMonitorTypeOptions(),
+];
+
 const MonitorControls = ({
   activePage,
   pageCount,
   search,
   state,
+  monitorType,
   onSearchChange,
   onStateChange,
+  onMonitorTypeChange,
   onPageClick,
   monitorActions = null,
 }) => (
@@ -45,6 +56,14 @@ const MonitorControls = ({
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <EuiCompressedSelect options={states} value={state} onChange={onStateChange} />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiCompressedSelect
+        options={monitorTypes}
+        value={monitorType}
+        onChange={onMonitorTypeChange}
+        data-test-subj="monitorTypeFilter"
+      />
     </EuiFlexItem>
     {monitorActions && <EuiFlexItem grow={false}>{monitorActions}</EuiFlexItem>}
   </EuiFlexGroup>

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -14,6 +14,8 @@ import MonitorControls from '../../components/MonitorControls';
 import MonitorEmptyPrompt from '../../components/MonitorEmptyPrompt';
 import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS } from './utils/constants';
 import { getURLQueryParams } from './utils/helpers';
+// Wazuh
+import { getActiveResponseNames, withActiveResponseColumn } from './utils/activeResponses';
 import { columns as staticColumns } from './utils/tableUtils';
 import { MONITOR_ACTIONS, MONITOR_TYPE } from '../../../../utils/constants';
 import { backendErrorNotification, deleteMonitor } from '../../../../utils/helpers';
@@ -35,7 +37,7 @@ export const EXCLUDED_OWNER = 'security_analytics'; // Wazuh: exclude monitors o
 export default class Monitors extends Component {
   constructor(props) {
     super(props);
-    const { from, size, search, sortField, sortDirection, state } = getURLQueryParams(
+    const { from, size, search, sortField, sortDirection, state, monitorType } = getURLQueryParams(
       this.props.location
     );
 
@@ -52,12 +54,15 @@ export default class Monitors extends Component {
       isPopoverOpen: false,
       monitors: [],
       monitorState: state,
+      monitorType, // Wazuh
+      activeResponseNames: {}, // Wazuh
       loadingMonitors: true,
       monitorItemsToDelete: undefined,
     };
     this.getMonitors = _.debounce(this.getMonitors.bind(this), 500, { leading: true });
     this.onTableChange = this.onTableChange.bind(this);
     this.onMonitorStateChange = this.onMonitorStateChange.bind(this);
+    this.onMonitorTypeChange = this.onMonitorTypeChange.bind(this); // Wazuh
     this.onSelectionChange = this.onSelectionChange.bind(this);
     this.onSearchChange = this.onSearchChange.bind(this);
     this.updateMonitor = this.updateMonitor.bind(this);
@@ -81,8 +86,12 @@ export default class Monitors extends Component {
   }
 
   componentDidMount() {
-    const { page, size, search, sortField, sortDirection, monitorState } = this.state;
-    this.getMonitors(page * size, size, search, sortField, sortDirection, monitorState);
+    const { page, size, search, sortField, sortDirection, monitorState, monitorType } = this.state;
+    this.getMonitors(page * size, size, search, sortField, sortDirection, monitorState, monitorType);
+    // Wazuh: the Active responses column holds names, the monitors only hold ids
+    getActiveResponseNames(this.props.httpClient)
+      .then((activeResponseNames) => this.setState({ activeResponseNames }))
+      .catch((err) => console.error(err));
   }
 
   buildColumns() {
@@ -124,7 +133,8 @@ export default class Monitors extends Component {
     );
 
     return [
-      ...staticColumns,
+      // Wazuh: name the active responses an Active Response monitor invokes
+      ...withActiveResponseColumn(staticColumns, this.state.activeResponseNames),
       {
         name: 'Actions',
         width: '60px',
@@ -145,11 +155,19 @@ export default class Monitors extends Component {
   }
 
   updateMonitorList() {
-    const { page, size, search, sortField, sortDirection, monitorState } = this.state;
-    this.getMonitors(page * size, size, search, sortField, sortDirection, monitorState);
+    const { page, size, search, sortField, sortDirection, monitorState, monitorType } = this.state;
+    this.getMonitors(page * size, size, search, sortField, sortDirection, monitorState, monitorType);
   }
 
-  getQueryObjectFromState({ page, size, search, sortField, sortDirection, monitorState }) {
+  getQueryObjectFromState({
+    page,
+    size,
+    search,
+    sortField,
+    sortDirection,
+    monitorState,
+    monitorType,
+  }) {
     return {
       page,
       size,
@@ -157,14 +175,16 @@ export default class Monitors extends Component {
       sortField,
       sortDirection,
       monitorState,
+      monitorType, // Wazuh
     };
   }
 
-  async getMonitors(from, size, search, sortField, sortDirection, state) {
+  async getMonitors(from, size, search, sortField, sortDirection, state, monitorType) {
     this.setState({ loadingMonitors: true });
     try {
       const dataSourceId = getDataSourceId();
-      const params = { from, size, search, sortField, sortDirection, state, dataSourceId, excludeOwner: EXCLUDED_OWNER };
+      // Wazuh: monitorType is filtered server side, so the total and the pages match the rows
+      const params = { from, size, search, sortField, sortDirection, state, dataSourceId, excludeOwner: EXCLUDED_OWNER, monitorType };
       const queryParamsString = queryString.stringify(params);
       const { httpClient, history } = this.props;
       history.replace({ ...this.props.location, search: queryParamsString });
@@ -199,6 +219,11 @@ export default class Monitors extends Component {
 
   onMonitorStateChange(e) {
     this.setState({ page: 0, monitorState: e.target.value });
+  }
+
+  // Wazuh
+  onMonitorTypeChange(e) {
+    this.setState({ page: 0, monitorType: e.target.value });
   }
 
   onSelectionChange(selectedItems) {
@@ -474,6 +499,7 @@ export default class Monitors extends Component {
       alerts,
       monitors,
       monitorState,
+      monitorType,
       page,
       search,
       selectedItems,
@@ -486,7 +512,10 @@ export default class Monitors extends Component {
       loadingMonitors,
       monitorItemsToDelete,
     } = this.state;
-    const filterIsApplied = !!search || monitorState !== DEFAULT_QUERY_PARAMS.state;
+    const filterIsApplied =
+      !!search ||
+      monitorState !== DEFAULT_QUERY_PARAMS.state ||
+      monitorType !== DEFAULT_QUERY_PARAMS.monitorType; // Wazuh
 
     const pagination = {
       pageIndex: page,
@@ -558,6 +587,8 @@ export default class Monitors extends Component {
             state={monitorState}
             onSearchChange={this.onSearchChange}
             onStateChange={this.onMonitorStateChange}
+            monitorType={monitorType}
+            onMonitorTypeChange={this.onMonitorTypeChange}
             onPageClick={this.onPageClick}
             monitorActions={useUpdatedUx ? monitorActions : null}
           />

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -37,6 +37,8 @@ exports[`Monitors renders 1`] = `
     <MonitorControls
       activePage={0}
       monitorActions={null}
+      monitorType="all"
+      onMonitorTypeChange={[Function]}
       onPageClick={[Function]}
       onSearchChange={[Function]}
       onStateChange={[Function]}
@@ -76,6 +78,12 @@ exports[`Monitors renders 1`] = `
               "truncateText": false,
             },
             Object {
+              "field": "item_type",
+              "name": "Active responses",
+              "render": [Function],
+              "truncateText": false,
+            },
+            Object {
               "field": "latestAlert",
               "name": "Latest alert",
               "sortable": false,
@@ -85,7 +93,7 @@ exports[`Monitors renders 1`] = `
             Object {
               "dataType": "date",
               "field": "lastNotificationTime",
-              "name": "Last notification time",
+              "name": "Last action time",
               "render": [Function],
               "sortable": true,
               "truncateText": false,

--- a/public/pages/Monitors/containers/Monitors/utils/activeResponses.js
+++ b/public/pages/Monitors/containers/Monitors/utils/activeResponses.js
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import { EuiBadge, EuiBadgeGroup } from '@elastic/eui';
 import {
   BACKEND_CHANNEL_TYPE,
   DEFAULT_EMPTY_DATA,
@@ -67,15 +66,7 @@ export const getActiveResponseColumn = (activeResponseNames = {}) => ({
     const ids = getMonitorActiveResponseIds(item.monitor);
     if (!ids.length) return NOT_APPLICABLE;
 
-    return (
-      <EuiBadgeGroup gutterSize="xs">
-        {ids.map((id) => (
-          <EuiBadge key={id} color={activeResponseNames[id] ? 'hollow' : 'danger'}>
-            {activeResponseNames[id] || `${id} (not found)`}
-          </EuiBadge>
-        ))}
-      </EuiBadgeGroup>
-    );
+    return ids.map((id) => activeResponseNames[id] || `${id} (not found)`).join(', ');
   },
 });
 

--- a/public/pages/Monitors/containers/Monitors/utils/activeResponses.js
+++ b/public/pages/Monitors/containers/Monitors/utils/activeResponses.js
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { EuiBadge, EuiBadgeGroup } from '@elastic/eui';
 import {
   BACKEND_CHANNEL_TYPE,
   DEFAULT_EMPTY_DATA,
@@ -66,7 +67,15 @@ export const getActiveResponseColumn = (activeResponseNames = {}) => ({
     const ids = getMonitorActiveResponseIds(item.monitor);
     if (!ids.length) return NOT_APPLICABLE;
 
-    return ids.map((id) => activeResponseNames[id] || `${id} (not found)`).join(', ');
+    return (
+      <EuiBadgeGroup gutterSize="xs">
+        {ids.map((id) => (
+          <EuiBadge key={id} color={activeResponseNames[id] ? 'hollow' : 'danger'}>
+            {activeResponseNames[id] || `${id} (not found)`}
+          </EuiBadge>
+        ))}
+      </EuiBadgeGroup>
+    );
   },
 });
 

--- a/public/pages/Monitors/containers/Monitors/utils/activeResponses.js
+++ b/public/pages/Monitors/containers/Monitors/utils/activeResponses.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  BACKEND_CHANNEL_TYPE,
+  DEFAULT_EMPTY_DATA,
+  MANAGED_CHANNEL_CATEGORY,
+  MAX_CHANNELS_RESULT_SIZE,
+  MONITOR_TYPE,
+} from '../../../../../utils/constants';
+import { getActionTypeFromAction } from '../../../../../utils/helpers';
+import NotificationService from '../../../../../services/NotificationService';
+import { getItemLevelType } from './helpers';
+
+const NOT_APPLICABLE = '–';
+
+const isActiveResponseAction = (action) => {
+  try {
+    return getActionTypeFromAction(action) === MANAGED_CHANNEL_CATEGORY.ACTIVE_RESPONSE;
+  } catch (err) {
+    return false; // an action saved before the categories existed
+  }
+};
+
+// The active responses a monitor invokes live in the actions of its triggers
+export const getMonitorActiveResponseIds = (monitor = {}) => {
+  const ids = (monitor.triggers || []).flatMap((trigger) =>
+    Object.values(trigger).flatMap((definition) =>
+      (definition?.actions || [])
+        .filter((action) => isActiveResponseAction(action) && action.destination_id)
+        .map((action) => action.destination_id)
+    )
+  );
+
+  return [...new Set(ids)];
+};
+
+// The trigger actions only hold ids, so the names are resolved once for the whole list
+export const getActiveResponseNames = async (httpClient) => {
+  const { items } = await new NotificationService(httpClient).getChannels({
+    from_index: 0,
+    max_items: MAX_CHANNELS_RESULT_SIZE,
+    config_type: BACKEND_CHANNEL_TYPE.ACTIVE_RESPONSE,
+    sort_field: 'name',
+    sort_order: 'asc',
+  });
+
+  return Object.fromEntries(items.map(({ config_id: configId, name }) => [configId, name]));
+};
+
+/*
+ * An Active Response monitor is armed by the active responses its triggers invoke, so the list
+ * names them the way it already names the associations of a composite monitor. A response that no
+ * longer exists is named by its id: a broken action is what the user most needs to see.
+ */
+export const getActiveResponseColumn = (activeResponseNames = {}) => ({
+  field: 'item_type',
+  name: 'Active responses',
+  truncateText: false,
+  render: (itemType, item) => {
+    if (itemType !== MONITOR_TYPE.ACTIVE_RESPONSE) return NOT_APPLICABLE;
+
+    const ids = getMonitorActiveResponseIds(item.monitor);
+    if (!ids.length) return NOT_APPLICABLE;
+
+    return ids.map((id) => activeResponseNames[id] || `${id} (not found)`).join(', ');
+  },
+});
+
+// Monitor type options for the list filter, skipping the types the list does not name
+export const getMonitorTypeOptions = () =>
+  Object.values(MONITOR_TYPE)
+    .map((monitorType) => ({ value: monitorType, text: getItemLevelType(monitorType) }))
+    .filter(({ text }) => text !== DEFAULT_EMPTY_DATA);
+
+// Placed next to the Type column, which is what it qualifies
+export const withActiveResponseColumn = (columns, activeResponseNames) => {
+  const withColumn = [...columns];
+  withColumn.splice(
+    withColumn.findIndex(({ field }) => field === 'item_type') + 1,
+    0,
+    getActiveResponseColumn(activeResponseNames)
+  );
+
+  return withColumn;
+};

--- a/public/pages/Monitors/containers/Monitors/utils/activeResponses.test.js
+++ b/public/pages/Monitors/containers/Monitors/utils/activeResponses.test.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
+import { mount } from 'enzyme';
+
 import {
   getActiveResponseColumn,
   getMonitorActiveResponseIds,
@@ -13,7 +16,13 @@ import { DEFAULT_EMPTY_DATA, MONITOR_TYPE } from '../../../../../utils/constants
 
 const renderColumn = (item, names) => {
   const { render } = getActiveResponseColumn(names);
-  return render(item.item_type, item);
+  const rendered = render(item.item_type, item);
+  return typeof rendered === 'string' ? rendered : mount(<div>{rendered}</div>).text();
+};
+
+const renderBadges = (item, names) => {
+  const { render } = getActiveResponseColumn(names);
+  return mount(<div>{render(item.item_type, item)}</div>).find('EuiBadge');
 };
 
 const activeResponseMonitor = (destinationId) => ({
@@ -90,6 +99,14 @@ describe('Monitors/utils/activeResponses', () => {
 
     test('flags an active response that no longer exists', () => {
       expect(renderColumn(activeResponseMonitor('ar-1'), {})).toBe('ar-1 (not found)');
+      expect(renderBadges(activeResponseMonitor('ar-1'), {}).first().props().color).toBe('danger');
+    });
+
+    test('badges each response the monitor invokes', () => {
+      const badges = renderBadges(activeResponseMonitor('ar-1'), { 'ar-1': 'Block-IP' });
+
+      expect(badges).toHaveLength(1);
+      expect(badges.first().props().color).toBe('hollow');
     });
 
     test('does not apply to the other monitor types', () => {

--- a/public/pages/Monitors/containers/Monitors/utils/activeResponses.test.js
+++ b/public/pages/Monitors/containers/Monitors/utils/activeResponses.test.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getActiveResponseColumn,
+  getMonitorActiveResponseIds,
+  getMonitorTypeOptions,
+} from './activeResponses';
+import { getItemLevelType } from './helpers';
+import { DEFAULT_EMPTY_DATA, MONITOR_TYPE } from '../../../../../utils/constants';
+
+const renderColumn = (item, names) => {
+  const { render } = getActiveResponseColumn(names);
+  return render(item.item_type, item);
+};
+
+const activeResponseMonitor = (destinationId) => ({
+  item_type: MONITOR_TYPE.ACTIVE_RESPONSE,
+  monitor: {
+    triggers: [
+      {
+        document_level_trigger: {
+          actions: [{ id: 'activeResponse1', destination_id: destinationId }],
+        },
+      },
+    ],
+  },
+});
+
+describe('Monitors/utils/activeResponses', () => {
+  describe('getMonitorActiveResponseIds', () => {
+    test('collects the active responses of every trigger, without duplicates', () => {
+      const monitor = {
+        triggers: [
+          {
+            document_level_trigger: {
+              actions: [
+                { id: 'activeResponse1', destination_id: 'ar-1' },
+                { id: 'notification1', destination_id: 'channel-1' },
+              ],
+            },
+          },
+          {
+            document_level_trigger: {
+              actions: [
+                { id: 'activeResponse2', destination_id: 'ar-1' },
+                { id: 'activeResponse3', destination_id: 'ar-2' },
+              ],
+            },
+          },
+        ],
+      };
+
+      expect(getMonitorActiveResponseIds(monitor)).toEqual(['ar-1', 'ar-2']);
+    });
+
+    test('returns an empty list when there is nothing to collect', () => {
+      expect(getMonitorActiveResponseIds()).toEqual([]);
+      expect(getMonitorActiveResponseIds({})).toEqual([]);
+      expect(getMonitorActiveResponseIds({ triggers: [{ query_level_trigger: {} }] })).toEqual([]);
+    });
+
+    test('ignores active response actions without a selected response', () => {
+      const monitor = {
+        triggers: [{ document_level_trigger: { actions: [{ id: 'activeResponse1' }] } }],
+      };
+
+      expect(getMonitorActiveResponseIds(monitor)).toEqual([]);
+    });
+  });
+
+  describe('getMonitorTypeOptions', () => {
+    test('offers every monitor type the list can name', () => {
+      const options = getMonitorTypeOptions();
+
+      expect(options).toContainEqual({
+        value: MONITOR_TYPE.ACTIVE_RESPONSE,
+        text: getItemLevelType(MONITOR_TYPE.ACTIVE_RESPONSE),
+      });
+      expect(options.every(({ text }) => text !== DEFAULT_EMPTY_DATA)).toBe(true);
+    });
+  });
+
+  describe('getActiveResponseColumn', () => {
+    test('names the active responses the monitor invokes', () => {
+      expect(renderColumn(activeResponseMonitor('ar-1'), { 'ar-1': 'Block-IP' })).toBe('Block-IP');
+    });
+
+    test('flags an active response that no longer exists', () => {
+      expect(renderColumn(activeResponseMonitor('ar-1'), {})).toBe('ar-1 (not found)');
+    });
+
+    test('does not apply to the other monitor types', () => {
+      expect(renderColumn({ item_type: MONITOR_TYPE.QUERY_LEVEL, monitor: {} }, {})).toBe('\u2013');
+    });
+
+    test('says nothing when the monitor invokes no active response', () => {
+      expect(renderColumn({ item_type: MONITOR_TYPE.ACTIVE_RESPONSE, monitor: {} }, {})).toBe(
+        '\u2013'
+      );
+    });
+  });
+});

--- a/public/pages/Monitors/containers/Monitors/utils/activeResponses.test.js
+++ b/public/pages/Monitors/containers/Monitors/utils/activeResponses.test.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { mount } from 'enzyme';
-
 import {
   getActiveResponseColumn,
   getMonitorActiveResponseIds,
@@ -16,13 +13,7 @@ import { DEFAULT_EMPTY_DATA, MONITOR_TYPE } from '../../../../../utils/constants
 
 const renderColumn = (item, names) => {
   const { render } = getActiveResponseColumn(names);
-  const rendered = render(item.item_type, item);
-  return typeof rendered === 'string' ? rendered : mount(<div>{rendered}</div>).text();
-};
-
-const renderBadges = (item, names) => {
-  const { render } = getActiveResponseColumn(names);
-  return mount(<div>{render(item.item_type, item)}</div>).find('EuiBadge');
+  return render(item.item_type, item);
 };
 
 const activeResponseMonitor = (destinationId) => ({
@@ -99,14 +90,6 @@ describe('Monitors/utils/activeResponses', () => {
 
     test('flags an active response that no longer exists', () => {
       expect(renderColumn(activeResponseMonitor('ar-1'), {})).toBe('ar-1 (not found)');
-      expect(renderBadges(activeResponseMonitor('ar-1'), {}).first().props().color).toBe('danger');
-    });
-
-    test('badges each response the monitor invokes', () => {
-      const badges = renderBadges(activeResponseMonitor('ar-1'), { 'ar-1': 'Block-IP' });
-
-      expect(badges).toHaveLength(1);
-      expect(badges.first().props().color).toBe('hollow');
     });
 
     test('does not apply to the other monitor types', () => {

--- a/public/pages/Monitors/containers/Monitors/utils/constants.js
+++ b/public/pages/Monitors/containers/Monitors/utils/constants.js
@@ -11,4 +11,5 @@ export const DEFAULT_QUERY_PARAMS = {
   sortField: 'name',
   sortDirection: 'desc',
   state: 'all',
+  monitorType: 'all', // Wazuh
 };

--- a/public/pages/Monitors/containers/Monitors/utils/helpers.js
+++ b/public/pages/Monitors/containers/Monitors/utils/helpers.js
@@ -15,6 +15,7 @@ export function getURLQueryParams(location) {
     sortField = DEFAULT_QUERY_PARAMS.sortField,
     sortDirection = DEFAULT_QUERY_PARAMS.sortDirection,
     state = DEFAULT_QUERY_PARAMS.state,
+    monitorType = DEFAULT_QUERY_PARAMS.monitorType, // Wazuh
   } = queryString.parse(location.search);
 
   return {
@@ -24,6 +25,7 @@ export function getURLQueryParams(location) {
     sortField,
     sortDirection,
     state,
+    monitorType, // Wazuh
   };
 }
 
@@ -36,7 +38,7 @@ export function getItemLevelType(itemType) {
     case MONITOR_TYPE.CLUSTER_METRICS:
       return 'Per cluster metrics';
     case MONITOR_TYPE.ACTIVE_RESPONSE:
-      return 'Active Response';
+      return 'Active response'; // Wazuh: the sibling types read in sentence case
     case MONITOR_TYPE.DOC_LEVEL:
       return 'Per document';
     case MONITOR_TYPE.COMPOSITE_LEVEL:

--- a/public/pages/Monitors/containers/Monitors/utils/helpers.test.js
+++ b/public/pages/Monitors/containers/Monitors/utils/helpers.test.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getItemLevelType, getURLQueryParams } from './helpers';
+import { DEFAULT_QUERY_PARAMS } from './constants';
+import { MONITOR_TYPE } from '../../../../../utils/constants';
+
+describe('Monitors/utils/helpers', () => {
+  test('names the Active Response monitor type in sentence case, like its siblings', () => {
+    expect(getItemLevelType(MONITOR_TYPE.ACTIVE_RESPONSE)).toBe('Active response');
+  });
+
+  test('reads the monitor type filter from the URL', () => {
+    expect(getURLQueryParams({ search: '?monitorType=active_response_monitor' }).monitorType).toBe(
+      MONITOR_TYPE.ACTIVE_RESPONSE
+    );
+    expect(getURLQueryParams({ search: '' }).monitorType).toBe(DEFAULT_QUERY_PARAMS.monitorType);
+  });
+});

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -50,7 +50,8 @@ export const columns = [
   },
   {
     field: 'lastNotificationTime',
-    name: 'Last notification time',
+    // Wazuh: an Active Response monitor executes a command instead of sending a notification
+    name: 'Last action time',
     sortable: true,
     truncateText: false,
     render: renderTime,

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -44,6 +44,23 @@ export const ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX = 'wazuh-findings';
 // Wazuh: Index pattern for findings indices used by Active Response monitors
 export const ACTIVE_RESPONSE_FINDINGS_INDEX_PATTERN = `${ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX}*`;
 
+// Wazuh: monitor types that name themselves in the copy of the create monitor form
+export const MONITOR_TYPE_LABEL = Object.freeze({
+  [MONITOR_TYPE.DOC_LEVEL]: 'document level monitors',
+  [MONITOR_TYPE.ACTIVE_RESPONSE]: 'Active Response monitors',
+});
+
+/*
+ * Wazuh: the indexer rejects an Active Response monitor whose schedule is longer than 60 seconds
+ * ("Active response monitor schedule must be <= 60 seconds"), or that is not an interval schedule.
+ */
+export const ACTIVE_RESPONSE_MAX_INTERVAL_SECONDS = 60;
+
+export const ACTIVE_RESPONSE_MAX_INTERVAL = Object.freeze({
+  SECONDS: ACTIVE_RESPONSE_MAX_INTERVAL_SECONDS,
+  MINUTES: ACTIVE_RESPONSE_MAX_INTERVAL_SECONDS / 60,
+});
+
 export const DESTINATION_ACTIONS = {
   UPDATE_DESTINATION: 'update-destination',
 };

--- a/public/utils/toastTracker.js
+++ b/public/utils/toastTracker.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Toasts are placed over the primary action bar and outlive the form that raised them, so they end
+ * up covering the Create button of the next form the user opens. A form wraps the notifications
+ * service with this tracker and removes its own toasts when it is left.
+ */
+const TRACKED_TOAST_METHODS = ['addSuccess', 'addWarning', 'addDanger', 'addError'];
+
+export const createToastTracker = (notifications) => {
+  if (!notifications?.toasts) return { notifications, removeAll: () => {} };
+
+  const raised = [];
+  const toasts = Object.create(notifications.toasts);
+
+  TRACKED_TOAST_METHODS.forEach((method) => {
+    toasts[method] = (...args) => {
+      const toast = notifications.toasts[method](...args);
+      if (toast) raised.push(toast);
+      return toast;
+    };
+  });
+
+  const trackedNotifications = Object.create(notifications);
+  trackedNotifications.toasts = toasts;
+
+  return {
+    notifications: trackedNotifications,
+    removeAll: () => raised.splice(0).forEach((toast) => notifications.toasts.remove(toast)),
+  };
+};

--- a/public/utils/toastTracker.test.js
+++ b/public/utils/toastTracker.test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createToastTracker } from './toastTracker';
+
+describe('createToastTracker', () => {
+  const getNotifications = () => ({
+    toasts: {
+      addSuccess: jest.fn((toast) => ({ id: toast })),
+      addDanger: jest.fn((toast) => ({ id: toast })),
+      remove: jest.fn(),
+    },
+  });
+
+  test('removes only the toasts it raised', () => {
+    const notifications = getNotifications();
+    const tracker = createToastTracker(notifications);
+
+    tracker.notifications.toasts.addSuccess('created');
+    tracker.notifications.toasts.addDanger('failed');
+    notifications.toasts.addSuccess('raised elsewhere');
+    tracker.removeAll();
+
+    expect(notifications.toasts.remove).toHaveBeenCalledTimes(2);
+    expect(notifications.toasts.remove).toHaveBeenCalledWith({ id: 'created' });
+    expect(notifications.toasts.remove).toHaveBeenCalledWith({ id: 'failed' });
+  });
+
+  test('removes each toast once', () => {
+    const notifications = getNotifications();
+    const tracker = createToastTracker(notifications);
+
+    tracker.notifications.toasts.addSuccess('created');
+    tracker.removeAll();
+    tracker.removeAll();
+
+    expect(notifications.toasts.remove).toHaveBeenCalledTimes(1);
+  });
+
+  test('does nothing without a notifications service', () => {
+    expect(() => createToastTracker(undefined).removeAll()).not.toThrow();
+  });
+});

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -5,7 +5,12 @@
 
 import _ from 'lodash';
 import { INDEX, MAX_THROTTLE_VALUE, WRONG_THROTTLE_WARNING } from '../../utils/constants';
-import { ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX, MONITOR_TYPE } from './constants';
+import {
+  ACTIVE_RESPONSE_FINDINGS_INDEX_PREFIX,
+  ACTIVE_RESPONSE_MAX_INTERVAL,
+  MONITOR_TYPE,
+  MONITOR_TYPE_LABEL,
+} from './constants';
 import { TRIGGER_TYPE } from '../pages/CreateTrigger/containers/CreateTrigger/utils/constants';
 import { getDataSourceQueryObj } from '../pages/utils/helpers';
 
@@ -141,6 +146,24 @@ export const validatePositiveInteger = (value) => {
   if (!Number.isInteger(value) || value < 1) return 'Must be a positive integer.';
 };
 
+/**
+ * Wazuh: the indexer caps an Active Response monitor schedule at 60 seconds, so the largest
+ * interval depends on the unit the schedule is expressed in.
+ */
+export const validateActiveResponseInterval = (unit) => (value) => {
+  const maxInterval = ACTIVE_RESPONSE_MAX_INTERVAL[unit];
+  if (!maxInterval) return validateActiveResponseUnit(unit);
+  if (!Number.isInteger(value) || value < 1 || value > maxInterval)
+    return `Must be between 1 and ${maxInterval} ${unit.toLowerCase()}.`;
+};
+
+export const validateActiveResponseUnit = (value) => {
+  if (!ACTIVE_RESPONSE_MAX_INTERVAL[value])
+    return `Must be one of ${Object.keys(ACTIVE_RESPONSE_MAX_INTERVAL)
+      .map((unit) => unit.toLowerCase())
+      .join(', ')}.`;
+};
+
 export const validateUnit = (value) => {
   if (!['MINUTES', 'HOURS', 'DAYS'].includes(value)) return 'Must be one of minutes, hours, days.';
 };
@@ -182,8 +205,11 @@ const MONITOR_TYPES_WITHOUT_INDEX_PATTERN_SUPPORT = [
 export const supportsIndexPatterns = (monitorType) =>
   !MONITOR_TYPES_WITHOUT_INDEX_PATTERN_SUPPORT.includes(monitorType);
 
-export const DOC_LEVEL_INDEX_PATTERN_ERROR =
-  'Index patterns are not supported for document level monitors. Select a single index instead of a wildcard (*) or date math pattern.';
+// Wazuh: name the monitor type the user actually selected
+export const getIndexPatternError = (monitorType) =>
+  `Index patterns are not supported for ${
+    MONITOR_TYPE_LABEL[monitorType] || 'these monitors'
+  }. Select a single index instead of a wildcard (*) or date math pattern.`;
 
 export const validateIndex = (options, monitorType) => {
   if (!Array.isArray(options)) return 'Must specify an index.';
@@ -200,7 +226,7 @@ export const validateIndex = (options, monitorType) => {
     !supportsIndexPatterns(monitorType) &&
     options.some(({ value, label }) => containsIndexPatternSyntax(value || label))
   ) {
-    return DOC_LEVEL_INDEX_PATTERN_ERROR;
+    return getIndexPatternError(monitorType);
   }
 };
 

--- a/public/utils/validate.test.js
+++ b/public/utils/validate.test.js
@@ -16,7 +16,9 @@ import {
   validateMonitorIndex,
   supportsIndexPatterns,
   containsIndexPatternSyntax,
-  DOC_LEVEL_INDEX_PATTERN_ERROR,
+  getIndexPatternError,
+  validateActiveResponseInterval,
+  validateActiveResponseUnit,
   isIndexPatternQueryValid,
   requiredNumber,
 } from './validate';
@@ -212,10 +214,10 @@ describe('validateIndex', () => {
   test('returns error string if a doc level monitor uses an index pattern', () => {
     [MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.ACTIVE_RESPONSE].forEach((monitorType) => {
       expect(validateIndex([{ label: 'wazuh-findings-v5-*' }], monitorType)).toBe(
-        DOC_LEVEL_INDEX_PATTERN_ERROR
+        getIndexPatternError(monitorType)
       );
       expect(validateIndex([{ label: '<wazuh-alerts-{now/d}>' }], monitorType)).toBe(
-        DOC_LEVEL_INDEX_PATTERN_ERROR
+        getIndexPatternError(monitorType)
       );
     });
   });
@@ -236,7 +238,7 @@ describe('validateIndex', () => {
 describe('validateMonitorIndex', () => {
   test('binds the monitor type to the validator', () => {
     expect(validateMonitorIndex(MONITOR_TYPE.DOC_LEVEL)([{ label: 'wazuh-alerts-*' }])).toBe(
-      DOC_LEVEL_INDEX_PATTERN_ERROR
+      getIndexPatternError(MONITOR_TYPE.DOC_LEVEL)
     );
     expect(
       validateMonitorIndex(MONITOR_TYPE.QUERY_LEVEL)([{ label: 'wazuh-alerts-*' }])
@@ -302,5 +304,45 @@ describe('requiredNumber', () => {
 
   test('returns error text for null value', () => {
     expect(requiredNumber(null)).toBe('Requires numerical value.');
+  });
+});
+
+// Wazuh: Active Response monitors run at most once per minute
+describe('validateActiveResponseInterval', () => {
+  test('caps the interval at 60 seconds', () => {
+    expect(validateActiveResponseInterval('SECONDS')(1)).toBeUndefined();
+    expect(validateActiveResponseInterval('SECONDS')(60)).toBeUndefined();
+    expect(validateActiveResponseInterval('SECONDS')(61)).toBe(
+      'Must be between 1 and 60 seconds.'
+    );
+  });
+
+  test('allows a single minute, and nothing longer', () => {
+    expect(validateActiveResponseInterval('MINUTES')(1)).toBeUndefined();
+    expect(validateActiveResponseInterval('MINUTES')(2)).toBe(
+      'Must be between 1 and 1 minutes.'
+    );
+  });
+
+  test('rejects non positive integers', () => {
+    [0, -1, 1.5, undefined].forEach((value) => {
+      expect(validateActiveResponseInterval('SECONDS')(value)).toBe(
+        'Must be between 1 and 60 seconds.'
+      );
+    });
+  });
+
+  test('rejects a unit the schedule cannot be expressed in', () => {
+    expect(validateActiveResponseInterval('HOURS')(1)).toBe(
+      'Must be one of seconds, minutes.'
+    );
+  });
+});
+
+describe('validateActiveResponseUnit', () => {
+  test('accepts seconds and minutes only', () => {
+    expect(validateActiveResponseUnit('SECONDS')).toBeUndefined();
+    expect(validateActiveResponseUnit('MINUTES')).toBeUndefined();
+    expect(validateActiveResponseUnit('DAYS')).toBe('Must be one of seconds, minutes.');
   });
 });

--- a/server/routes/monitors.js
+++ b/server/routes/monitors.js
@@ -18,6 +18,7 @@ export default function (services, router, dataSourceEnabled) {
     state: schema.string(),
     monitorIds: schema.maybe(schema.any()),
     excludeOwner: schema.maybe(schema.string()), // Wazuh: param to optionally exclude monitors by owner
+    monitorType: schema.maybe(schema.string()), // Wazuh: param to optionally filter monitors by type
   };
 
   router.get(

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -262,7 +262,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getMonitors = async (context, req, res) => {
     try {
-      const { from, size, search, sortDirection, sortField, state, monitorIds, excludeOwner } = req.query;
+      const { from, size, search, sortDirection, sortField, state, monitorIds, excludeOwner, monitorType } = req.query;
 
       let must = { match_all: {} };
       if (search.trim()) {
@@ -298,6 +298,19 @@ export default class MonitorService extends MDSEnabledClientService {
         const enabled = state === 'enabled';
         should.push({ term: { 'monitor.enabled': enabled } });
         should.push({ term: { 'workflow.enabled': enabled } });
+      }
+
+      // Wazuh: filter by monitor type here, so the total and the pages match the rows
+      if (monitorType && monitorType !== 'all') {
+        mustList.push({
+          bool: {
+            should: [
+              { term: { 'monitor.monitor_type': monitorType } },
+              { term: { 'workflow.workflow_type': monitorType } },
+            ],
+            minimum_should_match: 1,
+          },
+        });
       }
 
       const monitorSorts = { name: 'monitor.name.keyword' };


### PR DESCRIPTION
## Description

Setting up an Active Response monitor asks the user to arm an automated remediation
without showing the three facts that decide whether it is safe: what the response
does, where it runs, and whether it is enabled.

A response can be muted, or can target every agent in the environment. Both are
saved without comment today: one does nothing at all, the other runs on the whole
fleet. The selector already loads that configuration and throws it away.

The same monitor type also offered schedules the indexer rejects, an index hint
naming the wrong monitor type, two identical "Add ..." buttons, and a monitors list
that only spoke of notifications.

Closes #147

## Proposed Changes

**Trigger action**

- Each response in the selector shows its location and type, and a muted one is
  marked as not running.
- The selected response is expanded into a read-only summary: executable, type and
  location, with a warning when it targets every agent or is muted.
- The selector no longer prefixes every name with `[Active response]`, can be
  cleared, and the group heading no longer shows the raw `active_response` key.
- "Remove action" is a trash icon instead of a full-size red button. Dropped the
  help text that claimed names cannot contain certain characters; they can.

**Schedule**

The indexer rejects an Active Response monitor that is not scheduled on an interval,
or whose interval is longer than 60 seconds:

```
Active response monitor schedule must be <= 60 seconds; got 300000ms
Active response monitor schedule must be an interval schedule (cron schedules are not supported)
```

The form now offers the interval frequency with seconds or minutes, caps the value,
and states the limit.

**Copy and naming**

- The index hint names the monitor type the user selected, instead of always saying
  "document level monitors".
- The card reads "Active Response monitor", like "Per query monitor" and
  "Composite monitor". The monitors list Type column reads "Active response".

**Add action buttons**

Each button has an icon and a line saying what it does, so sending an alert is not
confused with running a command on an agent.

**Monitors list**

- New "Active responses" column naming the responses a monitor invokes, and the
  name of one that no longer exists.
- New monitor type filter, applied by the server so the count and the pages match
  the rows.
- "Last notification time" is now "Last action time": an Active Response monitor
  runs a command, it does not notify.

**Toasts**

A toast outlived the form that raised it and covered the Create button of the next
form. Each form now removes its own toasts when it is left. A failed update or a
network error reported nothing at all; both now show the error.

Placing toasts clear of the action bar belongs to the platform and is not part of
this pull request.

### Results and Evidence

<img width="1160" height="512" alt="Screenshot 2026-08-20 at 15 15 02" src="https://github.com/user-attachments/assets/596705d6-941e-494b-a656-a7ad6323b37e" />

<img width="1457" height="269" alt="Screenshot 2026-08-20 at 15 15 27" src="https://github.com/user-attachments/assets/9223896e-5d94-4bab-97cc-75dbd3a40fc6" />

<img width="778" height="445" alt="Screenshot 2026-08-20 at 15 24 02" src="https://github.com/user-attachments/assets/058900a2-0624-41fe-97fa-9bfc634d29fb" />

<img width="2928" height="1388" alt="image" src="https://github.com/user-attachments/assets/2a3a05d4-0e14-4fa9-8ac4-5680f13474b0" />

<img width="1428" height="559" alt="Screenshot 2026-08-20 at 15 26 01" src="https://github.com/user-attachments/assets/9c80264e-07ef-44a1-a4c3-a5fec279b6ea" />

<img width="1452" height="744" alt="Screenshot 2026-08-20 at 15 31 16" src="https://github.com/user-attachments/assets/46fcb179-b456-44e2-8433-fdf7bb2aa527" />



### Artifacts Affected

None. UI and API query only, no packaging or artifact changes.

### Configuration Changes

None.

### Documentation Updates

None required.

### Tests Introduced

New tests:

- `EnhancedAction.test.js` - option rows, badges, flat list, clearable field.
- `ActiveResponseSummary.test.js` - summary contents, both warnings, unmute link.
- `activeResponses.test.js` - responses collected from a monitor, list column,
  monitor type options.
- `toastTracker.test.js` - a form removes only the toasts it raised.
- `helpers.test.js` - Type column name, monitor type read from the URL.

Extended: `validate.test.js` (interval limits per unit), `Frequencies.test.js`
(available frequencies and units), `helper.test.js` (selector group names),
`MonitorIndex.test.js` (index hint per monitor type).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] Screenshots added for every UI change
